### PR TITLE
Make rainbow effects more colorful

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1082,7 +1082,7 @@ uint32_t Segment::color_wheel(uint8_t pos) const {
   if (palette) return color_from_palette(pos, false, false, 0); // only wrap if "always wrap" is set
   uint8_t w = W(getCurrentColor(0));
   uint32_t rgb;
-  hsv2rgb(CHSV32(pos, 255, 255), rgb);
+  hsv2rgb(CHSV32(static_cast<uint16_t>(pos << 8), 255, 255), rgb);
   return rgb | (w << 24); // add white channel
 }
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1076,26 +1076,23 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
 /*
  * Put a value 0 to 255 in to get a color value.
  * The colours are a transition r -> g -> b -> back to r
- * Inspired by the Adafruit examples.
+ * Rotates the color in HSV space, where pos is H. (0=0deg, 256=360deg)
  */
 uint32_t Segment::color_wheel(uint8_t pos) const {
   if (palette) return color_from_palette(pos, false, false, 0); // never wrap palette
   uint8_t w = W(getCurrentColor(0));
-  pos = 255 - pos;
-  if (useRainbowWheel) {
-    CRGB rgb;
-    hsv2rgb_rainbow(CHSV(pos, 255, 255), rgb);
-    return RGBW32(rgb.r, rgb.g, rgb.b, w);
-  } else {
-    if (pos < 85) {
-      return RGBW32((255 - pos * 3), 0, (pos * 3), w);
-    } else if (pos < 170) {
-      pos -= 85;
-      return RGBW32(0, (pos * 3), (255 - pos * 3), w);
-    } else {
-      pos -= 170;
-      return RGBW32((pos * 3), (255 - pos * 3), 0, w);
-    }
+  // These h and f values are the same h and f you have in the regular HSV to RGB conversion.
+  // The whole funciton really is just a HSV conversion, but assuming H=pos, S=1 and V=1.
+  const uint32_t h = (pos * 3) / 128;
+  const uint32_t f = (pos * 6) % 256;
+  switch (h) {
+    case 0: return RGBW32(255    , f      , 0      , w);
+    case 1: return RGBW32(255 - f, 255    , 0      , w);
+    case 2: return RGBW32(0      , 255    , f      , w);
+    case 3: return RGBW32(0      , 255 - f, 255    , w);
+    case 4: return RGBW32(f      , 0      , 255    , w);
+    case 5: return RGBW32(255    , 0      , 255 - f, w);
+    default: return 0;
   }
 }
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1079,21 +1079,11 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
  * Rotates the color in HSV space, where pos is H. (0=0deg, 256=360deg)
  */
 uint32_t Segment::color_wheel(uint8_t pos) const {
-  if (palette) return color_from_palette(pos, false, false, 0); // never wrap palette
+  if (palette) return color_from_palette(pos, false, false, 0); // only wrap if "always wrap" is set
   uint8_t w = W(getCurrentColor(0));
-  // These h and f values are the same h and f you have in the regular HSV to RGB conversion.
-  // The whole funciton really is just a HSV conversion, but assuming H=pos, S=1 and V=1.
-  const uint32_t h = (pos * 3) / 128;
-  const uint32_t f = (pos * 6) % 256;
-  switch (h) {
-    case 0: return RGBW32(255    , f      , 0      , w);
-    case 1: return RGBW32(255 - f, 255    , 0      , w);
-    case 2: return RGBW32(0      , 255    , f      , w);
-    case 3: return RGBW32(0      , 255 - f, 255    , w);
-    case 4: return RGBW32(f      , 0      , 255    , w);
-    case 5: return RGBW32(255    , 0      , 255 - f, w);
-    default: return 0;
-  }
+  uint32_t rgb;
+  hsv2rgb(CHSV32(pos, 255, 255), rgb);
+  return rgb | (w << 24); // add white channel
 }
 
 /*

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -518,7 +518,6 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(briMultiplier, light[F("scale-bri")]);
   CJSON(paletteBlend, light[F("pal-mode")]);
   CJSON(strip.autoSegments, light[F("aseg")]);
-  CJSON(useRainbowWheel, light[F("rw")]);
 
   CJSON(gammaCorrectVal, light["gc"]["val"]); // default 2.2
   float light_gc_bri = light["gc"]["bri"];
@@ -1040,7 +1039,6 @@ void serializeConfig(JsonObject root) {
   light[F("scale-bri")] = briMultiplier;
   light[F("pal-mode")] = paletteBlend;
   light[F("aseg")] = strip.autoSegments;
-  light[F("rw")] = useRainbowWheel;
 
   JsonObject light_gc = light.createNestedObject("gc");
   light_gc["bri"] = (gammaCorrectBri) ? gammaCorrectVal : 1.0f;  // keep compatibility

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -905,7 +905,6 @@ Swap: <select id="xw${s}" name="XW${s}">
 			<option value="3">None (not recommended)</option>
 		</select><br>
 		Use harmonic <i>Random Cycle</i> palette: <input type="checkbox" name="TH"><br>
-		Use &quot;rainbow&quot; color wheel: <input type="checkbox" name="RW"><br>
 		Target refresh rate: <input type="number" class="s" min="0" max="250" name="FR" oninput="UI()" required> FPS
 		<div id="fpsNone" class="warn" style="display: none;">&#9888; Unlimited FPS Mode is experimental &#9888;<br></div>
 		<div id="fpsHigh" class="warn" style="display: none;">&#9888; High FPS Mode is experimental.<br></div>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -348,7 +348,6 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     t = request->arg(F("TP")).toInt();
     randomPaletteChangeTime = MIN(255,MAX(1,t));
     useHarmonicRandomPalette = request->hasArg(F("TH"));
-    useRainbowWheel = request->hasArg(F("RW"));
 
     nightlightTargetBri = request->arg(F("TB")).toInt();
     t = request->arg(F("TL")).toInt();

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -623,7 +623,6 @@ WLED_GLOBAL unsigned long transitionStartTime;
 WLED_GLOBAL bool          jsonTransitionOnce       _INIT(false);  // flag to override transitionDelay (playlist, JSON API: "live" & "seg":{"i"} & "tt")
 WLED_GLOBAL uint8_t       randomPaletteChangeTime  _INIT(5);      // amount of time [s] between random palette changes (min: 1s, max: 255s)
 WLED_GLOBAL bool          useHarmonicRandomPalette _INIT(true);   // use *harmonic* random palette generation (nicer looking) or truly random
-WLED_GLOBAL bool          useRainbowWheel          _INIT(false);  // use "rainbow" color wheel instead of "spectrum" color wheel
 
 // nightlight
 WLED_GLOBAL bool nightlightActive _INIT(false);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -380,7 +380,6 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormValue(settingsScript,PSTR("TL"),nightlightDelayMinsDefault);
     printSetFormValue(settingsScript,PSTR("TW"),nightlightMode);
     printSetFormIndex(settingsScript,PSTR("PB"),paletteBlend);
-    printSetFormCheckbox(settingsScript,PSTR("RW"),useRainbowWheel);
     printSetFormValue(settingsScript,PSTR("RL"),rlyPin);
     printSetFormCheckbox(settingsScript,PSTR("RM"),rlyMde);
     printSetFormCheckbox(settingsScript,PSTR("RO"),rlyOpenDrain);


### PR DESCRIPTION
I was playing around with some rainbow effects and was wondering why there was no real yellow color. Cyan and magenta are also mysteriously underrepresented. I think rainbow effects should use the full rainbow spectrum.

If you agree, that is what this PR does.  
Here are two images displaying the Rainbow effect on 256 LEDs, captured using the web UI:

![rainbows](https://github.com/Aircoookie/WLED/assets/2760830/2b4e1afe-a7d7-4570-9916-b849332f8dbd)

Top: 0_15 (874b24fb320c6dc16e509514b70965bb4ca7964b)  
Bottom: mine (760a1d45124903070a62944faf6f0f3e95e9bbaf)

This works by replacing the linear transitions R -> G -> B in `color_wheel` by the HSV transition 0° -> 360°.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the color wheel to provide smoother and more consistent color transitions by rotating through HSV hues.

* **Bug Fixes**
  * Removed the "Use 'rainbow' color wheel" option from the LED settings in the user interface to streamline configuration.

* **Refactor**
  * Simplified color handling by removing the rainbow color wheel setting and related configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->