### PR TITLE
Update remote.cpp to allow parsing JSON over ESP NOW

### DIFF
--- a/wled00/remote.cpp
+++ b/wled00/remote.cpp
@@ -191,7 +191,7 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
 
 void handleRemote() {
   if (enable_espnow_remote) {
-    if ((esp_now_state == ESP_NOW_STATE_UNINIT) && (interfacesInited || apActive)) {
+    if ((esp_now_state == ESP_NOW_STATE_UNINIT) && (interfacesInited || apActive)) { // ESPNOW requires Wifi to be initialized (either STA, or AP Mode) 
       DEBUG_PRINTLN(F("Initializing ESP_NOW listener"));
       // Init ESP-NOW
       if (esp_now_init() != 0) {


### PR DESCRIPTION
This little change has allowed me to send a JSON over ESPNow and it works well. 
```json
{
  "command":{
  "on": true,
  "bri": 100,
  "seg": [
    {
      "col": [[128, 0, 128]],
      "fx": 0
    }
  ]
  },
}
````
I am not very mature with codes and need someone to peer review the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for processing incoming JSON strings in remote data packets.

- **Bug Fixes**
  - Improved handling of unexpected data packet formats to prevent errors.

- **Other**
  - Minor code cleanup for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->