### PR TITLE
Improvements to pinwheel algorithm, should work on any size and should also be faster

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1111,7 +1111,7 @@ uint16_t mode_running_random(void) {
 
   unsigned z = it % zoneSize;
   bool nzone = (!z && it != SEGENV.aux1);
-  for (unsigned i=SEGLEN-1; i > 0; i--) {
+  for (int i=SEGLEN-1; i >= 0; i--) {
     if (nzone || z >= zoneSize) {
       unsigned lastrand = PRNG16 >> 8;
       int16_t diff = 0;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1111,7 +1111,7 @@ uint16_t mode_running_random(void) {
 
   unsigned z = it % zoneSize;
   bool nzone = (!z && it != SEGENV.aux1);
-  for (int i=SEGLEN-1; i >= 0; i--) {
+  for (int i=SEGLEN-1; i > 0; i--) {
     if (nzone || z >= zoneSize) {
       unsigned lastrand = PRNG16 >> 8;
       int16_t diff = 0;

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -169,7 +169,7 @@ bool sendLiveLedsWs(uint32_t wsClient)
 #ifdef ESP8266
   const size_t MAX_LIVE_LEDS_WS = 256U;
 #else
-  const size_t MAX_LIVE_LEDS_WS = 1024U;
+  const size_t MAX_LIVE_LEDS_WS = 4096U;
 #endif
   size_t n = ((used -1)/MAX_LIVE_LEDS_WS) +1; //only serve every n'th LED if count over MAX_LIVE_LEDS_WS
   size_t pos = 2;  // start of data

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -169,7 +169,7 @@ bool sendLiveLedsWs(uint32_t wsClient)
 #ifdef ESP8266
   const size_t MAX_LIVE_LEDS_WS = 256U;
 #else
-  const size_t MAX_LIVE_LEDS_WS = 4096U;
+  const size_t MAX_LIVE_LEDS_WS = 1024U;
 #endif
   size_t n = ((used -1)/MAX_LIVE_LEDS_WS) +1; //only serve every n'th LED if count over MAX_LIVE_LEDS_WS
   size_t pos = 2;  // start of data


### PR DESCRIPTION
- should now work on larger setups, tested at vaious sizes from 8x8 - 32x32 and on 128x16
- Increased fixed point shift to 15bit
- fixed 'pixel holes' on large sizes
- speed should be improved too
- consolidated code to save flash (about -300 bytes)
- reduced 'pixel stepping' to 50% steps to fix pixel holes (increases number of loops but it has no measurable impact on speed)