### PR TITLE
ESP32-S2-Mini constantly reboots

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -609,13 +609,13 @@ void WLED::initAP(bool resetAP)
     WLED_SET_AP_SSID();
     strcpy_P(apPass, PSTR(WLED_AP_PASS));
   }
+  #ifdef ARDUINO_ARCH_ESP32
+  WiFi.setTxPower(wifi_power_t(txPower));
+  #endif
   DEBUG_PRINT(F("Opening access point "));
   DEBUG_PRINTLN(apSSID);
   WiFi.softAPConfig(IPAddress(4, 3, 2, 1), IPAddress(4, 3, 2, 1), IPAddress(255, 255, 255, 0));
   WiFi.softAP(apSSID, apPass, apChannel, apHide);
-  #ifdef ARDUINO_ARCH_ESP32
-  WiFi.setTxPower(wifi_power_t(txPower));
-  #endif
 
   if (!apActive) // start captive portal if AP active
   {


### PR DESCRIPTION
Soultion addresses problem where SOME of the ESP-S2-Mini's would constanly reboot itself, thus never allowing the Access Point to initialize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the sequence of setting WiFi transmit power for ESP32 devices during access point initialization. No changes to user-facing features or controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->