### PR TITLE
bugfix: avoid effect overspeed during transitions (solves #4446)

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1388,7 +1388,7 @@ void WS2812FX::service() {
         }
 #endif
         seg.call++;
-        if (seg.isInTransition() && frameDelay > FRAMETIME) frameDelay = FRAMETIME; // force faster updates during transition
+        if (seg.isInTransition() && frameDelay > FRAMETIME_FIXED) frameDelay = FRAMETIME_FIXED; // force faster updates during transition, if requested time is below 40 fps
         BusManager::setSegmentCCT(oldCCT); // restore old CCT for ABL adjustments
       }
 


### PR DESCRIPTION
this still raises FPS during transitions, but only for effects that normally run very slow (solid).