### PR TITLE
Fixed UDP Realtime streaming in DNRGBW Mode

### DIFF
--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -605,8 +605,8 @@ void handleNotifications()
     return;
   }
 
-  //UDP realtime: 1 warls 2 drgb 3 drgbw
-  if (udpIn[0] > 0 && udpIn[0] < 5)
+  //UDP realtime: 1 warls 2 drgb 3 drgbw 4 dnrgb 5 dnrgbw
+  if (udpIn[0] > 0 && udpIn[0] < 6)
   {
     realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
     DEBUG_PRINTLN(realtimeIP);


### PR DESCRIPTION
The udp.cpp class contained code to handle dnrgbw as a possible format, however a earlier if filtered out the possibility of actually using that mode due to not accepting the first protocol selection byte being 5 (4 is dnrgb, 5 was already added to be dnrgb**w**, however then filtered out again)