### PR TITLE
"Unlimited" buses

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -942,8 +942,8 @@ void BusManager::on() {
       uint8_t pins[2] = {255,255};
       if (bus->isDigital() && bus->getPins(pins)) {
         if (pins[0] == LED_BUILTIN || pins[1] == LED_BUILTIN) {
-          BusDigital *b = static_cast<BusDigital*>(bus);
-          b->begin();
+          BusDigital &b = static_cast<BusDigital&>(*bus);
+          b.begin();
           break;
         }
       }

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -145,7 +145,7 @@ BusDigital::BusDigital(const BusConfig &bc, uint8_t nr)
   _hasWhite = hasWhite(bc.type);
   _hasCCT = hasCCT(bc.type);
   if (bc.doubleBuffer) {
-    _data = (uint8_t*)d_calloc(_len, Bus::getNumberOfChannels(_type));
+    _data = (uint8_t*)calloc(_len, Bus::getNumberOfChannels(_type));
     if (!_data) DEBUG_PRINTLN(F("Bus: Buffer allocation failed!"));
   }
   uint16_t lenToCreate = bc.count;
@@ -744,7 +744,7 @@ BusNetwork::BusNetwork(const BusConfig &bc)
   _hasCCT = false;
   _UDPchannels = _hasWhite + 3;
   _client = IPAddress(bc.pins[0],bc.pins[1],bc.pins[2],bc.pins[3]);
-  _data = (uint8_t*)d_calloc(_len, _UDPchannels);
+  _data = (uint8_t*)calloc(_len, _UDPchannels);
   _valid = (_data != nullptr);
   DEBUG_PRINTF_P(PSTR("%successfully inited virtual strip with type %u and IP %u.%u.%u.%u\n"), _valid?"S":"Uns", bc.type, bc.pins[0], bc.pins[1], bc.pins[2], bc.pins[3]);
 }

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -384,13 +384,13 @@ uint32_t IRAM_ATTR BusDigital::getPixelColor(unsigned pix) const {
   }
 }
 
-unsigned BusDigital::getPins(uint8_t* pinArray) const {
+size_t BusDigital::getPins(uint8_t* pinArray) const {
   unsigned numPins = is2Pin(_type) + 1;
   if (pinArray) for (unsigned i = 0; i < numPins; i++) pinArray[i] = _pins[i];
   return numPins;
 }
 
-unsigned BusDigital::getBusSize() const {
+size_t BusDigital::getBusSize() const {
   return sizeof(BusDigital) + (isOk() ? PolyBus::getDataSize(_busPtr, _iType) + (_data ? _len * getNumberOfChannels() : 0) : 0);
 }
 
@@ -573,7 +573,7 @@ uint32_t BusPwm::getPixelColor(unsigned pix) const {
 
 void BusPwm::show() {
   if (!_valid) return;
-  const unsigned numPins = getPins();
+  const size_t   numPins = getPins();
 #ifdef ESP8266
    const unsigned analogPeriod = F_CPU / _frequency;
    const unsigned maxBri = analogPeriod;  // compute to clock cycle accuracy
@@ -640,7 +640,7 @@ void BusPwm::show() {
   }
 }
 
-unsigned BusPwm::getPins(uint8_t* pinArray) const {
+size_t BusPwm::getPins(uint8_t* pinArray) const {
   if (!_valid) return 0;
   unsigned numPins = numPWMPins(_type);
   if (pinArray) for (unsigned i = 0; i < numPins; i++) pinArray[i] = _pins[i];
@@ -660,7 +660,7 @@ std::vector<LEDType> BusPwm::getLEDTypes() {
 }
 
 void BusPwm::deallocatePins() {
-  unsigned numPins = getPins();
+  size_t numPins = getPins();
   for (unsigned i = 0; i < numPins; i++) {
     PinManager::deallocatePin(_pins[i], PinOwner::BusPwm);
     if (!PinManager::isPinOk(_pins[i])) continue;
@@ -716,7 +716,7 @@ void BusOnOff::show() {
   digitalWrite(_pin, _reversed ? !(bool)_data[0] : (bool)_data[0]);
 }
 
-unsigned BusOnOff::getPins(uint8_t* pinArray) const {
+size_t BusOnOff::getPins(uint8_t* pinArray) const {
   if (!_valid) return 0;
   if (pinArray) pinArray[0] = _pin;
   return 1;
@@ -780,7 +780,7 @@ void BusNetwork::show() {
   _broadcastLock = false;
 }
 
-unsigned BusNetwork::getPins(uint8_t* pinArray) const {
+size_t BusNetwork::getPins(uint8_t* pinArray) const {
   if (pinArray) for (unsigned i = 0; i < 4; i++) pinArray[i] = _client[i];
   return 4;
 }
@@ -808,7 +808,7 @@ void BusNetwork::cleanup() {
 
 
 //utility to get the approx. memory usage of a given BusConfig
-unsigned BusConfig::memUsage(unsigned nr) const {
+size_t BusConfig::memUsage(unsigned nr) const {
   if (Bus::isVirtual(type)) {
     return sizeof(BusNetwork) + (count * Bus::getNumberOfChannels(type));
   } else if (Bus::isDigital(type)) {
@@ -821,7 +821,7 @@ unsigned BusConfig::memUsage(unsigned nr) const {
 }
 
 
-unsigned BusManager::memUsage() {
+size_t BusManager::memUsage() {
   // when ESP32, S2 & S3 use parallel I2S only the largest bus determines the total memory requirements for back buffers
   // front buffers are always allocated per bus
   unsigned size = 0;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -125,6 +125,7 @@ BusDigital::BusDigital(const BusConfig &bc, uint8_t nr)
 , _colorOrder(bc.colorOrder)
 , _milliAmpsPerLed(bc.milliAmpsPerLed)
 , _milliAmpsMax(bc.milliAmpsMax)
+, _data(nullptr)
 {
   if (!isDigital(bc.type) || !bc.count) return;
   if (!PinManager::allocatePin(bc.pins[0], true, PinOwner::BusDigital)) return;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -153,8 +153,17 @@ BusDigital::BusDigital(const BusConfig &bc, uint8_t nr)
   uint16_t lenToCreate = bc.count;
   if (bc.type == TYPE_WS2812_1CH_X3) lenToCreate = NUM_ICS_WS2812_1CH_3X(bc.count); // only needs a third of "RGB" LEDs for NeoPixelBus
   _busPtr = PolyBus::create(_iType, _pins, lenToCreate + _skip, nr);
-  _valid = (_busPtr != nullptr);
-  DEBUG_PRINTF_P(PSTR("%successfully inited strip %u (len %u) with type %u and pins %u,%u (itype %u). mA=%d/%d\n"), _valid?"S":"Uns", nr, bc.count, bc.type, _pins[0], is2Pin(bc.type)?_pins[1]:255, _iType, _milliAmpsPerLed, _milliAmpsMax);
+  _valid = (_busPtr != nullptr) && bc.count > 0;
+  DEBUG_PRINTF_P(PSTR("Bus: %successfully inited #%u (len:%u, type:%u (RGB:%d, W:%d, CCT:%d), pins:%u,%u [itype:%u] mA=%d/%d)\n"),
+    _valid?"S":"Uns",
+    (int)nr,
+    (int)bc.count,
+    (int)bc.type,
+    (int)_hasRgb, (int)_hasWhite, (int)_hasCCT,
+    (unsigned)_pins[0], is2Pin(bc.type)?(unsigned)_pins[1]:255U,
+    (unsigned)_iType,
+    (int)_milliAmpsPerLed, (int)_milliAmpsMax
+  );
 }
 
 //DISCLAIMER
@@ -734,7 +743,7 @@ BusNetwork::BusNetwork(const BusConfig &bc)
   _hasCCT = false;
   _UDPchannels = _hasWhite + 3;
   _client = IPAddress(bc.pins[0],bc.pins[1],bc.pins[2],bc.pins[3]);
-  _valid = (allocateData(_len * _UDPchannels) != nullptr);
+  _valid = (allocateData(_len * _UDPchannels) != nullptr) && bc.count > 0;
   DEBUG_PRINTF_P(PSTR("%successfully inited virtual strip with type %u and IP %u.%u.%u.%u\n"), _valid?"S":"Uns", bc.type, bc.pins[0], bc.pins[1], bc.pins[2], bc.pins[3]);
 }
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -21,6 +21,7 @@ make_unique(Args&&... args)
 {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+#endif
 
 // enable additional debug output
 #if defined(WLED_DEBUG_HOST)

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -429,7 +429,7 @@ namespace BusManager {
   // WARNING: setSegmentCCT() is a misleading name!!! much better would be setGlobalCCT() or just setCCT()
   void           setSegmentCCT(int16_t cct, bool allowWBCorrection = false);
   inline int16_t getSegmentCCT()         { return Bus::getCCT(); }
-  inline Bus&    getBus(uint8_t busNr)   { return *busses[std::min((size_t)busNr, busses.size()-1)]; }
+  inline Bus*    getBus(size_t busNr)    { return busNr < busses.size() ? busses[busNr].get() : nullptr; }
   inline uint8_t getNumBusses()          { return busses.size(); }
 
   //semi-duplicate of strip.getLengthTotal() (though that just returns strip._length, calculated in finalizeInit())

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -876,8 +876,7 @@ void serializeConfig() {
   const ColorOrderMap& com = BusManager::getColorOrderMap();
   for (size_t s = 0; s < com.count(); s++) {
     const ColorOrderMapEntry *entry = com.get(s);
-    if (!entry) break;
-
+    if (!entry || !entry->len) break;
     JsonObject co = hw_com.createNestedObject();
     co["start"] = entry->start;
     co["len"] = entry->len;

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -192,7 +192,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     #endif
 
     for (JsonObject elm : ins) {
-      if (s >= WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES) break;
+      if (s >= WLED_MAX_BUSSES) break;
       uint8_t pins[5] = {255, 255, 255, 255, 255};
       JsonArray pinArr = elm["pin"];
       if (pinArr.size() == 0) continue;
@@ -220,21 +220,11 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
         maMax = 0;
       }
       ledType |= refresh << 7; // hack bit 7 to indicate strip requires off refresh
-      if (fromFS) {
-        BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz, useGlobalLedBuffer, maPerLed, maMax);
-        if (useParallel && s < 8) {
-          // if for some unexplained reason the above pre-calculation was wrong, update
-          unsigned memT = BusManager::memUsage(bc); // includes x8 memory allocation for parallel I2S
-          if (memT > mem) mem = memT; // if we have unequal LED count use the largest
-        } else
-          mem += BusManager::memUsage(bc); // includes global buffer
-        if (mem <= MAX_LED_MEMORY) if (BusManager::add(bc) == -1) break;  // finalization will be done in WLED::beginStrip()
-      } else {
-        if (busConfigs[s] != nullptr) delete busConfigs[s];
-        busConfigs[s] = new BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz, useGlobalLedBuffer, maPerLed, maMax);
-        doInitBusses = true;  // finalization done in beginStrip()
-      }
-      s++;
+
+      //busConfigs.push_back(std::move(BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz, useGlobalLedBuffer, maPerLed, maMax)));
+      busConfigs.emplace_back(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz, useGlobalLedBuffer, maPerLed, maMax);
+      doInitBusses = true;  // finalization done in beginStrip()
+      if (!Bus::isVirtual(ledType)) s++; // have as many virtual buses as you want
     }
     DEBUG_PRINTF_P(PSTR("LED buffer size: %uB\n"), mem);
     DEBUG_PRINTF_P(PSTR("Heap after buses: %d\n"), ESP.getFreeHeap());

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -49,31 +49,31 @@
     #define WLED_MAX_DIGITAL_CHANNELS 3
     #define WLED_MAX_ANALOG_CHANNELS 5
     #define WLED_MAX_BUSSES 4                 // will allow 3 digital & 1 analog RGB
-    #define WLED_MIN_VIRTUAL_BUSSES 2
+    #define WLED_MIN_VIRTUAL_BUSSES 3         // no longer used for bus creation but used to distinguish S2/S3 in UI
   #else
     #define WLED_MAX_ANALOG_CHANNELS (LEDC_CHANNEL_MAX*LEDC_SPEED_MODE_MAX)
     #if defined(CONFIG_IDF_TARGET_ESP32C3)    // 2 RMT, 6 LEDC, only has 1 I2S but NPB does not support it ATM
       #define WLED_MAX_BUSSES 6               // will allow 2 digital & 2 analog RGB or 6 PWM white
       #define WLED_MAX_DIGITAL_CHANNELS 2
       //#define WLED_MAX_ANALOG_CHANNELS 6
-      #define WLED_MIN_VIRTUAL_BUSSES 3
+      #define WLED_MIN_VIRTUAL_BUSSES 4       // no longer used for bus creation but used to distinguish S2/S3 in UI
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)  // 4 RMT, 8 LEDC, only has 1 I2S bus, supported in NPB
       // the 5th bus (I2S) will prevent Audioreactive usermod from functioning (it is last used though)
       #define WLED_MAX_BUSSES 7               // will allow 5 digital & 2 analog RGB
       #define WLED_MAX_DIGITAL_CHANNELS 5
       //#define WLED_MAX_ANALOG_CHANNELS 8
-      #define WLED_MIN_VIRTUAL_BUSSES 3
-    #elif defined(CONFIG_IDF_TARGET_ESP32S3)  // 4 RMT, 8 LEDC, has 2 I2S but NPB does not support them ATM
-      #define WLED_MAX_BUSSES 6               // will allow 4 digital & 2 analog RGB
-      #define WLED_MAX_DIGITAL_CHANNELS 4
+      #define WLED_MIN_VIRTUAL_BUSSES 4       // no longer used for bus creation but used to distinguish S2/S3 in UI
+    #elif defined(CONFIG_IDF_TARGET_ESP32S3)  // 4 RMT, 8 LEDC, has 2 I2S but NPB supports parallel x8 LCD on I2S1
+      #define WLED_MAX_BUSSES 14              // will allow 12 digital & 2 analog RGB
+      #define WLED_MAX_DIGITAL_CHANNELS 12    // x4 RMT + x8 I2S-LCD
       //#define WLED_MAX_ANALOG_CHANNELS 8
-      #define WLED_MIN_VIRTUAL_BUSSES 4
+      #define WLED_MIN_VIRTUAL_BUSSES 6       // no longer used for bus creation but used to distinguish S2/S3 in UI
     #else
       // the last digital bus (I2S0) will prevent Audioreactive usermod from functioning
       #define WLED_MAX_BUSSES 20              // will allow 17 digital & 3 analog RGB
       #define WLED_MAX_DIGITAL_CHANNELS 17
       //#define WLED_MAX_ANALOG_CHANNELS 16
-      #define WLED_MIN_VIRTUAL_BUSSES 4
+      #define WLED_MIN_VIRTUAL_BUSSES 6       // no longer used for bus creation but used to distinguish S2/S3 in UI
     #endif
   #endif
 #else
@@ -87,7 +87,7 @@
     #ifndef WLED_MAX_DIGITAL_CHANNELS
       #error You must also define WLED_MAX_DIGITAL_CHANNELS.
     #endif
-    #define WLED_MIN_VIRTUAL_BUSSES (5-WLED_MAX_BUSSES)
+    #define WLED_MIN_VIRTUAL_BUSSES 3
   #else
     #if WLED_MAX_BUSSES > 20
       #error Maximum number of buses is 20.
@@ -98,7 +98,11 @@
     #ifndef WLED_MAX_DIGITAL_CHANNELS
       #error You must also define WLED_MAX_DIGITAL_CHANNELS.
     #endif
-    #define WLED_MIN_VIRTUAL_BUSSES (20-WLED_MAX_BUSSES)
+    #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
+      #define WLED_MIN_VIRTUAL_BUSSES 4
+    #else
+      #define WLED_MIN_VIRTUAL_BUSSES 6
+    #endif
   #endif
 #endif
 

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -42,10 +42,10 @@
 			if (loc) d.Sf.action = getURL('/settings/leds');
 		}
 		function bLimits(b,v,p,m,l,o=5,d=2,a=6) {
-			oMaxB = maxB = b; // maxB - max buses (can be changed if using ESP32 parallel I2S)
-			maxD  = d; // maxD - max digital channels (can be changed if using ESP32 parallel I2S)
-			maxA  = a; // maxA - max analog channels
-			maxV  = v; // maxV - min virtual buses
+			oMaxB = maxB = b; // maxB - max buses (can be changed if using ESP32 parallel I2S): 20 - ESP32, 14 - S3/S2, 6 - C3, 4 - 8266
+			maxD  = d; // maxD - max digital channels (can be changed if using ESP32 parallel I2S): 17 - ESP32, 12 - S3/S2, 2 - C3, 3 - 8266
+			maxA  = a; // maxA - max analog channels: 16 - ESP32, 8 - S3/S2, 6 - C3, 5 - 8266
+			maxV  = v; // maxV - min virtual buses: 6 - ESP32/S3, 4 - S2/C3, 3 - ESP8266 (only used to distinguish S2/S3)
 			maxPB = p; // maxPB - max LEDs per bus
 			maxM  = m; // maxM - max LED memory
 			maxL  = l; // maxL - max LEDs (will serve to determine ESP >1664 == ESP32)
@@ -350,6 +350,18 @@
 						else LC.style.color = d.ro_gpio.some((e)=>e==parseInt(LC.value)) ? "orange" : "#fff";
 					}
 			});
+			const S2 = (oMaxB == 14) && (maxV == 4);
+			const S3 = (oMaxB == 14) && (maxV == 6);
+			if (oMaxB == 19 || S2 || S3) { // TODO: crude ESP32 & S2/S3 detection
+				if (maxLC > 300 || dC <= 2) {
+					d.Sf["PR"].checked = false;
+					gId("prl").classList.add("hide");
+				} else
+					gId("prl").classList.remove("hide");
+				// S2 supports mono I2S as well as parallel so we need to take that into account; S3 only supports parallel
+				maxD = (S2 || S3 ? 4 : 8) + (d.Sf["PR"].checked ? 8 : S2); // TODO: use bLimits() : 4/8RMT + (x1/x8 parallel) I2S1
+				maxB = oMaxB - (d.Sf["PR"].checked ? 0 : 7 + S3); // S2 (maxV==4) does support mono I2S
+			}
 			// distribute ABL current if not using PPL
 			enPPL(sDI);
 
@@ -409,8 +421,8 @@
 				if (isVir(t)) virtB++;
 			});
 
-			if ((n==1 && i>=maxB+maxV) || (n==-1 && i==0)) return;
-			var s = String.fromCharCode((i<10?48:55)+i);
+			if ((n==1 && i>=36) || (n==-1 && i==0)) return; // used to be i>=maxB+maxV when virtual buses were limited (now :"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+			var s = chrID(i);
 
 			if (n==1) {
 // npm run build has trouble minimizing spaces inside string
@@ -484,7 +496,7 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 				o[i].querySelector("[name^=LT]").disabled = false;
 			}
 
-			gId("+").style.display = (i<maxB+maxV-1) ? "inline":"none";
+			gId("+").style.display = (i<35) ? "inline":"none"; // was maxB+maxV-1 when virtual buses were limited (now :"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 			gId("-").style.display = (i>0) ? "inline":"none";
 
 			if (!init) {
@@ -603,22 +615,32 @@ Swap: <select id="xw${s}" name="XW${s}">
 
 			function receivedText(e) {
 				let lines = e.target.result;
-				var c = JSON.parse(lines); 
+				let c = JSON.parse(lines); 
 				if (c.hw) {
 					if (c.hw.led) {
-						for (var i=0; i<10; i++) addLEDs(-1);
-						var l = c.hw.led;
+						// remove all existing outputs
+						for (const i=0; i<36; i++) addLEDs(-1); // was i<maxb+maxV when number of virtual buses was limited (now :"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+						let l = c.hw.led;
 						l.ins.forEach((v,i,a)=>{
 							addLEDs(1);
 							for (var j=0; j<v.pin.length; j++) d.getElementsByName(`L${j}${i}`)[0].value = v.pin[j];
-							d.getElementsByName("LT"+i)[0].value = v.type;
-							d.getElementsByName("LS"+i)[0].value = v.start;
-							d.getElementsByName("LC"+i)[0].value = v.len;
-							d.getElementsByName("CO"+i)[0].value = v.order;
-							d.getElementsByName("SL"+i)[0].value = v.skip;
+							d.getElementsByName("LT"+i)[0].value   = v.type;
+							d.getElementsByName("LS"+i)[0].value   = v.start;
+							d.getElementsByName("LC"+i)[0].value   = v.len;
+							d.getElementsByName("CO"+i)[0].value   = v.order & 0x0F;
+							d.getElementsByName("SL"+i)[0].value   = v.skip;
 							d.getElementsByName("RF"+i)[0].checked = v.ref;
 							d.getElementsByName("CV"+i)[0].checked = v.rev;
+							d.getElementsByName("AW"+i)[0].value   = v.rgbwm;
+							d.getElementsByName("WO"+i)[0].value   = (v.order>>4) & 0x0F;
+							d.getElementsByName("SP"+i)[0].value   = v.freq;
+							d.getElementsByName("LA"+i)[0].value   = v.ledma;
+							d.getElementsByName("MA"+i)[0].value   = v.maxpwr;
 						});
+						d.getElementsByName("PR")[0].checked  = l.prl | 0;
+						d.getElementsByName("LD")[0].checked  = l.ld;
+						d.getElementsByName("MA")[0].value    = l.maxpwr;
+						d.getElementsByName("ABL")[0].checked = l.maxpwr > 0;
 					}
 					if(c.hw.com) {
 						resetCOM();
@@ -626,22 +648,28 @@ Swap: <select id="xw${s}" name="XW${s}">
 							addCOM(e.start, e.len, e.order);
 						});
 					}
-					if (c.hw.btn) {
-						var b = c.hw.btn;
+					let b = c.hw.btn;
+					if (b) {
 						if (Array.isArray(b.ins)) gId("btns").innerHTML = "";
 						b.ins.forEach((v,i,a)=>{
 							addBtn(i,v.pin[0],v.type);
 						});
 						d.getElementsByName("TT")[0].value = b.tt;
 					}
-					if (c.hw.ir) {
-						d.getElementsByName("IR")[0].value = c.hw.ir.pin;
-						d.getElementsByName("IT")[0].value = c.hw.ir.type;
+					let ir = c.hw.ir;
+					if (ir) {
+						d.getElementsByName("IR")[0].value = ir.pin;
+						d.getElementsByName("IT")[0].value = ir.type;
 					}
-					if (c.hw.relay) {
-						d.getElementsByName("RL")[0].value = c.hw.relay.pin;
-						d.getElementsByName("RM")[0].checked = c.hw.relay.rev;
-						d.getElementsByName("RO")[0].checked = c.hw.relay.odrain;
+					let rl = c.hw.relay;
+					if (rl) {
+						d.getElementsByName("RL")[0].value   = rl.pin;
+						d.getElementsByName("RM")[0].checked = rl.rev;
+						d.getElementsByName("RO")[0].checked = rl.odrain;
+					}
+					let li = c.light;
+					if (li) {
+						d.getElementsByName("MS")[0].checked  = li.aseg;
 					}
 					UI();
 				}

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -141,7 +141,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     useGlobalLedBuffer = request->hasArg(F("LD"));
 
     bool busesChanged = false;
-    for (int s = 0; s < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; s++) {
+    for (int s = 0; s < 36; s++) { // theoretical limit is 36 : "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       int offset = s < 10 ? 48 : 55;
       char lp[4] = "L0"; lp[2] = offset+s; lp[3] = 0; //ascii 0-9 //strip data pin
       char lc[4] = "LC"; lc[2] = offset+s; lc[3] = 0; //strip length
@@ -157,7 +157,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       char la[4] = "LA"; la[2] = offset+s; la[3] = 0; //LED mA
       char ma[4] = "MA"; ma[2] = offset+s; ma[3] = 0; //max mA
       if (!request->hasArg(lp)) {
-        DEBUG_PRINTF_P(PSTR("No data for %d\n"), s);
+        DEBUG_PRINTF_P(PSTR("# of buses: %d\n"), s+1);
         break;
       }
       for (int i = 0; i < 5; i++) {

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -208,8 +208,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       type |= request->hasArg(rf) << 7; // off refresh override
       // actual finalization is done in WLED::loop() (removing old busses and adding new)
       // this may happen even before this loop is finished so we do "doInitBusses" after the loop
-      if (busConfigs[s] != nullptr) delete busConfigs[s];
-      busConfigs[s] = new(std::nothrow) BusConfig(type, pins, start, length, colorOrder | (channelSwap<<4), request->hasArg(cv), skip, awmode, freq, useGlobalLedBuffer, maPerLed, maMax);
+      busConfigs.emplace_back(type, pins, start, length, colorOrder | (channelSwap<<4), request->hasArg(cv), skip, awmode, freq, useGlobalLedBuffer, maPerLed, maMax);
       busesChanged = true;
     }
     //doInitBusses = busesChanged; // we will do that below to ensure all input data is processed

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -891,12 +891,11 @@ WLED_GLOBAL ESPAsyncE131 ddp  _INIT_N(((handleE131Packet)));
 WLED_GLOBAL bool e131NewData _INIT(false);
 
 // led fx library object
-WLED_GLOBAL BusManager busses _INIT(BusManager());
-WLED_GLOBAL WS2812FX strip _INIT(WS2812FX());
-WLED_GLOBAL BusConfig* busConfigs[WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES] _INIT({nullptr}); //temporary, to remember values from network callback until after
-WLED_GLOBAL bool doInitBusses _INIT(false);
-WLED_GLOBAL int8_t loadLedmap _INIT(-1);
-WLED_GLOBAL uint8_t currentLedmap _INIT(0);
+WLED_GLOBAL WS2812FX   strip         _INIT(WS2812FX());
+WLED_GLOBAL std::vector<BusConfig> busConfigs;    //temporary, to remember values from network callback until after
+WLED_GLOBAL bool       doInitBusses  _INIT(false);
+WLED_GLOBAL int8_t     loadLedmap    _INIT(-1);
+WLED_GLOBAL uint8_t    currentLedmap _INIT(0);
 #ifndef ESP8266
 WLED_GLOBAL char  *ledmapNames[WLED_MAX_LEDMAPS-1] _INIT_N(({nullptr}));
 #endif

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -292,8 +292,8 @@ void getSettingsJS(byte subPage, Print& settingsScript)
 
     unsigned sumMa = 0;
     for (int s = 0; s < BusManager::getNumBusses(); s++) {
-      Bus* bus = BusManager::getBus(s);
-      if (bus == nullptr) continue;
+      const Bus *bus = BusManager::getBus(s);
+      if (!bus || !bus->isOk()) break; // should not happen but for safety
       int offset = s < 10 ? 48 : 55;
       char lp[4] = "L0"; lp[2] = offset+s; lp[3] = 0; //ascii 0-9 //strip data pin
       char lc[4] = "LC"; lc[2] = offset+s; lc[3] = 0; //strip length
@@ -312,7 +312,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
       uint8_t pins[5];
       int nPins = bus->getPins(pins);
       for (int i = 0; i < nPins; i++) {
-        lp[1] = offset+i;
+        lp[1] = '0'+i;
         if (PinManager::isPinOk(pins[i]) || bus->isVirtual()) printSetFormValue(settingsScript,lp,pins[i]);
       }
       printSetFormValue(settingsScript,lc,bus->getLength());

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -357,7 +357,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     const ColorOrderMap& com = BusManager::getColorOrderMap();
     for (int s = 0; s < com.count(); s++) {
       const ColorOrderMapEntry* entry = com.get(s);
-      if (entry == nullptr) break;
+      if (!entry || !entry->len) break;
       settingsScript.printf_P(PSTR("addCOM(%d,%d,%d);"), entry->start, entry->len, entry->colorOrder);
     }
 

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -272,7 +272,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     // set limits
     settingsScript.printf_P(PSTR("bLimits(%d,%d,%d,%d,%d,%d,%d,%d);"),
       WLED_MAX_BUSSES,
-      WLED_MIN_VIRTUAL_BUSSES,
+      WLED_MIN_VIRTUAL_BUSSES, // irrelevant, but kept to distinguish S2/S3 in UI
       MAX_LEDS_PER_BUS,
       MAX_LED_MEMORY,
       MAX_LEDS,


### PR DESCRIPTION
Add ability to have up to 36 (theoretical limit) buses, physical or virtual.

Stuff also done:
- converted BusManager from class to namespace
- modified BusConfig to use vector
- modified ColorOrderMap::getPixelColorOrder() to use vector (and removed ColorOrderMap from BusDigital)
- updated loading config into UI (LED settings, buttons, etc.)

WARNING web server may not support that many variables when creating buses so actual limit may be less.

Many thanks to @willmmiles @TripleWhy and @PaoloTK for helpful comments and suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

• New Features  
 - Expanded support for LED configurations on select hardware, enabling increased digital channel capacity and more flexible setups.  
 - Enhanced debugging output for bus configurations, improving troubleshooting capabilities.  

• Bug Fixes  
 - Enhanced error checking and validation during hardware bus initialization, reducing the risk of improper configurations and runtime issues.  

• Refactor  
 - Streamlined configuration processing and resource management, leading to improved system stability, performance, and maintainability.  
 - Improved memory management through the use of modern C++ features, enhancing code safety and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->