### PR TITLE
Consolidate classic FX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wled",
-  "version": "0.16.0-dev",
+  "version": "0.16.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wled",
-      "version": "0.16.0-dev",
+      "version": "0.16.0-alpha",
       "license": "ISC",
       "dependencies": {
         "clean-css": "^5.3.3",

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -500,7 +500,7 @@ uint16_t mode_theater_chase() {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size,,,,Animate palette,,Chase;!,!;!;;o1=0,o3=0";
+static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size,,,,Rainbow,,Theater;!,!;!;;o1=0,o3=1";
 
 
 /*
@@ -539,7 +539,7 @@ static uint16_t mode_running_lights() {
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Width,,,,Animate palette,Dual,Saw;L,!,R;!";
+static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Width,,,,Rainbow,Dual,Saw;L,!,R;!";
 
 
 /*
@@ -579,12 +579,13 @@ static const char _data_FX_MODE_TWINKLE[] PROGMEM = "Twinkle@!,!;!,!;!;;m12=0"; 
 
 
 /*
- * Dissolve function
+ * Dissolve function: Blink several LEDs on and then off
  */
-uint16_t dissolve(uint32_t color) {
+uint16_t mode_dissolve(void) {
   unsigned dataSize = sizeof(uint32_t) * SEGLEN;
   if (!SEGENV.allocateData(dataSize)) return mode_static(); //allocation failed
   uint32_t* pixels = reinterpret_cast<uint32_t*>(SEGENV.data);
+  uint32_t color = SEGMENT.check1 ? SEGMENT.color_wheel(hw_random8()) : SEGCOLOR(0);
 
   if (SEGENV.call == 0) {
     for (unsigned i = 0; i < SEGLEN; i++) pixels[i] = SEGCOLOR(1);
@@ -621,25 +622,7 @@ uint16_t dissolve(uint32_t color) {
 
   return FRAMETIME;
 }
-
-
-/*
- * Blink several LEDs on and then off
- */
-uint16_t mode_dissolve(void) {
-  return dissolve(SEGMENT.check1 ? SEGMENT.color_wheel(hw_random8()) : SEGCOLOR(0));
-}
 static const char _data_FX_MODE_DISSOLVE[] PROGMEM = "Dissolve@Repeat speed,Dissolve speed,,,,Random;!,!;!";
-
-
-/*
- * Blink several LEDs on and then off in random colors
- */
-//uint16_t mode_dissolve_random(void) {
-//  return dissolve(SEGMENT.color_wheel(hw_random8()));
-//}
-//static const char _data_FX_MODE_DISSOLVE_RANDOM[] PROGMEM = "Dissolve Rnd@Repeat speed,Dissolve speed;,!;!";
-
 
 /*
  * Blinks one LED at a time.
@@ -662,7 +645,7 @@ uint16_t mode_sparkle(void) {
   SEGMENT.setPixelColor(SEGENV.aux0, SEGCOLOR(0));
   return FRAMETIME;
 }
-static const char _data_FX_MODE_SPARKLE[] PROGMEM = "Sparkle@!,,,,,Animate palette,Overlay;!,!;!;;m12=0,01=0";
+static const char _data_FX_MODE_SPARKLE[] PROGMEM = "Sparkle@!,,,,,Move,Overlay;!,!;!;;m12=0,01=0";
 
 
 /*
@@ -687,7 +670,7 @@ uint16_t mode_flash_sparkle(void) {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_FLASH_SPARKLE[] PROGMEM = "Sparkle Dark@!,!,,,,Animate palette,Overlay;Bg,Fx;!;;m12=0";
+static const char _data_FX_MODE_FLASH_SPARKLE[] PROGMEM = "Sparkle Dark@!,!,,,,Move,Overlay;Bg,Fx;!;;m12=0";
 
 
 /*
@@ -715,7 +698,7 @@ uint16_t mode_hyper_sparkle(void) {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_HYPER_SPARKLE[] PROGMEM = "Sparkle+@!,!,,,,Animate palette,Overlay;Bg,Fx;!;;m12=0";
+static const char _data_FX_MODE_HYPER_SPARKLE[] PROGMEM = "Sparkle+@!,!,,,,Move,Overlay;Bg,Fx;!;;m12=0";
 
 
 /*
@@ -749,7 +732,7 @@ uint16_t mode_multi_strobe(void) {
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_MULTI_STROBE[] PROGMEM = "Strobe Mega@!,!,,,,Animate palette;!,!;!;01;o1=0";
+static const char _data_FX_MODE_MULTI_STROBE[] PROGMEM = "Strobe Mega@!,!,,,,Move;!,!;!;01;o1=0";
 
 
 /*
@@ -1031,7 +1014,7 @@ uint16_t mode_chase_flash(void) {
   }
   return delay;
 }
-static const char _data_FX_MODE_CHASE_FLASH[] PROGMEM = "Chase Flash@!,,,,,Animate palette;Bg,Fx;!;;o1=0";
+static const char _data_FX_MODE_CHASE_FLASH[] PROGMEM = "Chase Flash@!,,,,,Animate BG;Bg,Fx;!;;o1=0";
 
 
 /*
@@ -1156,7 +1139,7 @@ uint16_t mode_larson_scanner(void) {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_LARSON_SCANNER[] PROGMEM = "Scanner@!,Trail,Delay,,,Animate palette,Bi-delay,Dual;!,!,!;!;;m12=0,c1=0,o1=0,o3=0";
+static const char _data_FX_MODE_LARSON_SCANNER[] PROGMEM = "Scanner@!,Trail,Delay,,,Shift palette,Bi-delay,Dual;!,!,!;!;;m12=0,c1=0,o1=0,o3=0";
 
 
 /*
@@ -3256,7 +3239,7 @@ uint16_t mode_candle() {
 
   return FRAMETIME_FIXED;
 }
-static const char _data_FX_MODE_CANDLE[] PROGMEM = "Candle@!,!,,,,,,Multi;!,!;!;01;sx=96,ix=224,pal=0,o3=1";
+static const char _data_FX_MODE_CANDLE[] PROGMEM = "Candle@!,!,,,,,,Multi;!,!;!;01;sx=96,ix=224,pal=0";
 
 #ifdef WLED_PS_DONT_REPLACE_FX
 /*
@@ -10124,7 +10107,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_COLORTWINKLE, &mode_colortwinkle, _data_FX_MODE_COLORTWINKLE);
   addEffect(FX_MODE_LAKE, &mode_lake, _data_FX_MODE_LAKE);
   addEffect(FX_MODE_METEOR, &mode_meteor, _data_FX_MODE_METEOR);
-  //addEffect(FX_MODE_METEOR_SMOOTH, &mode_meteor_smooth, _data_FX_MODE_METEOR_SMOOTH); // merged with mode_meteor 
+  //addEffect(FX_MODE_METEOR_SMOOTH, &mode_meteor_smooth, _data_FX_MODE_METEOR_SMOOTH); // merged with mode_meteor
   addEffect(FX_MODE_RAILWAY, &mode_railway, _data_FX_MODE_RAILWAY);
   addEffect(FX_MODE_RIPPLE, &mode_ripple, _data_FX_MODE_RIPPLE);
   addEffect(FX_MODE_TWINKLEFOX, &mode_twinklefox, _data_FX_MODE_TWINKLEFOX);
@@ -10136,11 +10119,11 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_SPOTS_FADE, &mode_spots_fade, _data_FX_MODE_SPOTS_FADE);
   addEffect(FX_MODE_COMET, &mode_comet, _data_FX_MODE_COMET);
   #ifdef WLED_PS_DONT_REPLACE_FX
-  addEffect(FX_MODE_MULTI_COMET, &mode_multi_comet, _data_FX_MODE_MULTI_COMET);  
+  addEffect(FX_MODE_MULTI_COMET, &mode_multi_comet, _data_FX_MODE_MULTI_COMET);
   addEffect(FX_MODE_ROLLINGBALLS, &rolling_balls, _data_FX_MODE_ROLLINGBALLS);
   addEffect(FX_MODE_SPARKLE, &mode_sparkle, _data_FX_MODE_SPARKLE);
   addEffect(FX_MODE_GLITTER, &mode_glitter, _data_FX_MODE_GLITTER);
-  addEffect(FX_MODE_SOLID_GLITTER, &mode_solid_glitter, _data_FX_MODE_SOLID_GLITTER);
+  //addEffect(FX_MODE_SOLID_GLITTER, &mode_solid_glitter, _data_FX_MODE_SOLID_GLITTER);
   addEffect(FX_MODE_STARBURST, &mode_starburst, _data_FX_MODE_STARBURST);
   addEffect(FX_MODE_DANCING_SHADOWS, &mode_dancing_shadows, _data_FX_MODE_DANCING_SHADOWS);
   addEffect(FX_MODE_FIRE_2012, &mode_fire_2012, _data_FX_MODE_FIRE_2012);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -360,19 +360,6 @@ static const char _data_FX_MODE_DYNAMIC[] PROGMEM = "Dynamic@!,!,,,,Smooth;;!";
 
 
 /*
- * effect "Dynamic" with smooth color-fading
- */
-//uint16_t mode_dynamic_smooth(void) {
-//  bool old = SEGMENT.check1;
-//  SEGMENT.check1 = true;
-//  mode_dynamic();
-//  SEGMENT.check1 = old;
-//  return FRAMETIME;
-//}
-//static const char _data_FX_MODE_DYNAMIC_SMOOTH[] PROGMEM = "Dynamic Smooth@!,!;;!";
-
-
-/*
  * Does the "standby-breathing" of well known i-Devices.
  */
 uint16_t mode_breath(void) {
@@ -411,10 +398,11 @@ static const char _data_FX_MODE_FADE[] PROGMEM = "Fade@!;!,!;!;01";
 
 
 /*
- * Scan mode parent function
+ * Runs a single pixel back and forth.
  */
-uint16_t scan(bool dual) {
+uint16_t mode_scan(void) {
   if (SEGLEN <= 1) return mode_static();
+  const bool dual = SEGMENT.check3;
   uint32_t cycleTime = 750 + (255 - SEGMENT.speed)*150;
   uint32_t perc = strip.now % cycleTime;
   int prog = (perc * 65535) / cycleTime;
@@ -439,24 +427,7 @@ uint16_t scan(bool dual) {
 
   return FRAMETIME;
 }
-
-
-/*
- * Runs a single pixel back and forth.
- */
-uint16_t mode_scan(void) {
-  return scan(false);
-}
-static const char _data_FX_MODE_SCAN[] PROGMEM = "Scan@!,# of dots,,,,,Overlay;!,!,!;!";
-
-
-/*
- * Runs two pixel back and forth in opposite directions.
- */
-uint16_t mode_dual_scan(void) {
-  return scan(true);
-}
-static const char _data_FX_MODE_DUAL_SCAN[] PROGMEM = "Scan Dual@!,# of dots,,,,,Overlay;!,!,!;!";
+static const char _data_FX_MODE_SCAN[] PROGMEM = "Scan@!,Size,,,,,Overlay,Dual;!,!,!;!;1;o1=0";
 
 
 /*
@@ -496,27 +467,31 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 
 
 /*
- * Alternating pixels running function.
+ * Alternating pixels running function / Theatre-style crawling lights.
+ * Inspired by the Adafruit examples.
  */
-static uint16_t running(uint32_t color1, uint32_t color2, bool theatre = false) {
+uint16_t mode_theater_chase() {
+  const bool animate = SEGMENT.check1;
+  const bool theatre = SEGMENT.check3;
   int width = (theatre ? 3 : 1) + (SEGMENT.intensity >> 4);  // window
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
   uint32_t it = strip.now / cycleTime;
-  bool usePalette = color1 == SEGCOLOR(0);
 
   for (unsigned i = 0; i < SEGLEN; i++) {
-    uint32_t col = color2;
-    if (usePalette) {
-      unsigned palIdx = SEGMENT.check1 ? (i+it)%SEGLEN : i;
-      color1 = SEGMENT.color_from_palette(palIdx, true, SEGMENT.check1, 0);
+    uint32_t c1 = SEGMENT.color_from_palette(i, true, false, 0);
+    uint32_t c2 = SEGCOLOR(1);
+    if (animate) {
+      c1 = SEGMENT.color_wheel(SEGENV.step); // sets moving palette and rainbow for default
+      //unsigned palIdx = animate ? (i+it)%SEGLEN : i;
+      //c1 = SEGMENT.color_from_palette(palIdx, true, animate, 0);
     }
     if (theatre) {
-      if ((i % width) == SEGENV.aux0) col = color1;
+      if ((i % width) == SEGENV.aux0) c2 = c1;
     } else {
       int pos = (i % (width<<1));
-      if ((pos < SEGENV.aux0-width) || ((pos >= SEGENV.aux0) && (pos < SEGENV.aux0+width))) col = color1;
+      if ((pos < SEGENV.aux0-width) || ((pos >= SEGENV.aux0) && (pos < SEGENV.aux0+width))) c2 = c1;
     }
-    SEGMENT.setPixelColor(i,col);
+    SEGMENT.setPixelColor(i,c2);
   }
 
   if (it != SEGENV.step) {
@@ -525,32 +500,15 @@ static uint16_t running(uint32_t color1, uint32_t color2, bool theatre = false) 
   }
   return FRAMETIME;
 }
-
-
-/*
- * Theatre-style crawling lights.
- * Inspired by the Adafruit examples.
- */
-uint16_t mode_theater_chase(void) {
-  return running(SEGCOLOR(0), SEGCOLOR(1), true);
-}
-static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size,,,,Animate palette;!,!;!;;o1=0";
-
-
-/*
- * Theatre-style crawling lights with rainbow effect.
- * Inspired by the Adafruit examples.
- */
-uint16_t mode_theater_chase_rainbow(void) {
-  return running(SEGMENT.color_wheel(SEGENV.step), SEGCOLOR(1), true);
-}
-static const char _data_FX_MODE_THEATER_CHASE_RAINBOW[] PROGMEM = "Theater Rainbow@!,Gap size;,!;!;;o1=0";
+static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size,,,,Animate palette,,Chase;!,!;!;;o1=0,o3=0";
 
 
 /*
  * Running lights effect with smooth sine transition base.
+ * Idea: Make the gap width controllable with a third slider in the future
  */
-static uint16_t running_base(bool saw, bool dual=false) {
+static uint16_t running_base(bool saw) {
+  const bool dual = SEGMENT.check3;
   unsigned x_scale = SEGMENT.intensity >> 2;
   uint32_t counter = (strip.now * SEGMENT.speed) >> 9;
   const bool moving = SEGMENT.check1;
@@ -582,24 +540,13 @@ static uint16_t running_base(bool saw, bool dual=false) {
   return FRAMETIME;
 }
 
-
-/*
- * Running lights in opposite directions.
- * Idea: Make the gap width controllable with a third slider in the future
- */
-uint16_t mode_running_dual(void) {
-  return running_base(false, true);
-}
-static const char _data_FX_MODE_RUNNING_DUAL[] PROGMEM = "Running Dual@!,Wave width,,,,Animate palette;L,!,R;!;;o1=0";
-
-
 /*
  * Running lights effect with smooth sine transition.
  */
 uint16_t mode_running_lights(void) {
   return running_base(false);
 }
-static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Wave width,,,,Animate palette;!,!;!;;o1=0";
+static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Wave width,,,,Animate palette,,Dual;!,!;!;;o1=0";
 
 
 /*
@@ -608,7 +555,7 @@ static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Wave width
 uint16_t mode_saw(void) {
   return running_base(true);
 }
-static const char _data_FX_MODE_SAW[] PROGMEM = "Saw@!,Width,,,,Animate palette;!,!;!;;o1=0";
+static const char _data_FX_MODE_SAW[] PROGMEM = "Saw@!,Width,,,,Animate palette;!,!;!;;o1=0,o3=0";
 
 
 /*
@@ -1137,15 +1084,6 @@ uint16_t mode_chase_flash_random(void) {
   return delay;
 }
 static const char _data_FX_MODE_CHASE_FLASH_RANDOM[] PROGMEM = "Chase Flash Rnd@!;!,!;!";
-
-
-/*
- * Alternating color/sec pixels running.
- */
-uint16_t mode_running_color(void) {
-  return running(SEGCOLOR(0), SEGCOLOR(1));
-}
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width;!,!;!";
 
 
 /*
@@ -3334,13 +3272,9 @@ static const char _data_FX_MODE_POPCORN[] PROGMEM = "Popcorn@!,!,,,,,Overlay;!,!
 //Inspired by https://github.com/avanhanegem/ArduinoCandleEffectNeoPixel
 //and https://cpldcpu.wordpress.com/2016/01/05/reverse-engineering-a-real-candle/
 
-uint16_t candle(bool multi)
-{
-  if (multi && SEGLEN > 1) {
-    //allocate segment data
-    unsigned dataSize = max(1, (int)SEGLEN -1) *3; //max. 1365 pixels (ESP8266)
-    if (!SEGENV.allocateData(dataSize)) return candle(false); //allocation failed
-  }
+uint16_t mode_candle() {
+  const unsigned dataSize = max(1, (int)SEGLEN -1) *3; //max. 1365 pixels (ESP8266)
+  const bool multi = SEGMENT.check3 && SEGLEN > 1 && SEGENV.allocateData(dataSize);
 
   //max. flicker range controlled by intensity
   unsigned valrange = SEGMENT.intensity;
@@ -3407,20 +3341,7 @@ uint16_t candle(bool multi)
 
   return FRAMETIME_FIXED;
 }
-
-
-uint16_t mode_candle()
-{
-  return candle(false);
-}
-static const char _data_FX_MODE_CANDLE[] PROGMEM = "Candle@!,!;!,!;!;01;sx=96,ix=224,pal=0";
-
-
-uint16_t mode_candle_multi()
-{
-  return candle(true);
-}
-static const char _data_FX_MODE_CANDLE_MULTI[] PROGMEM = "Candle Multi@!,!;!,!;!;;sx=96,ix=224,pal=0";
+static const char _data_FX_MODE_CANDLE[] PROGMEM = "Candle@!,!,,,,,,Multi;!,!;!;01;sx=96,ix=224,pal=0,o3=1";
 
 #ifdef WLED_PS_DONT_REPLACE_FX
 /*
@@ -10224,10 +10145,10 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_RAINBOW, &mode_rainbow, _data_FX_MODE_RAINBOW);
   addEffect(FX_MODE_RAINBOW_CYCLE, &mode_rainbow_cycle, _data_FX_MODE_RAINBOW_CYCLE);
   addEffect(FX_MODE_SCAN, &mode_scan, _data_FX_MODE_SCAN);
-  addEffect(FX_MODE_DUAL_SCAN, &mode_dual_scan, _data_FX_MODE_DUAL_SCAN);
+  //addEffect(FX_MODE_DUAL_SCAN, &mode_dual_scan, _data_FX_MODE_DUAL_SCAN);
   addEffect(FX_MODE_FADE, &mode_fade, _data_FX_MODE_FADE);
   addEffect(FX_MODE_THEATER_CHASE, &mode_theater_chase, _data_FX_MODE_THEATER_CHASE);
-  addEffect(FX_MODE_THEATER_CHASE_RAINBOW, &mode_theater_chase_rainbow, _data_FX_MODE_THEATER_CHASE_RAINBOW);
+  //addEffect(FX_MODE_THEATER_CHASE_RAINBOW, &mode_theater_chase_rainbow, _data_FX_MODE_THEATER_CHASE_RAINBOW);
   addEffect(FX_MODE_RUNNING_LIGHTS, &mode_running_lights, _data_FX_MODE_RUNNING_LIGHTS);
   addEffect(FX_MODE_SAW, &mode_saw, _data_FX_MODE_SAW);
   addEffect(FX_MODE_TWINKLE, &mode_twinkle, _data_FX_MODE_TWINKLE);
@@ -10250,7 +10171,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_COLORFUL, &mode_colorful, _data_FX_MODE_COLORFUL);
   addEffect(FX_MODE_TRAFFIC_LIGHT, &mode_traffic_light, _data_FX_MODE_TRAFFIC_LIGHT);
   addEffect(FX_MODE_COLOR_SWEEP_RANDOM, &mode_color_sweep_random, _data_FX_MODE_COLOR_SWEEP_RANDOM);
-  addEffect(FX_MODE_RUNNING_COLOR, &mode_running_color, _data_FX_MODE_RUNNING_COLOR);
+  //addEffect(FX_MODE_RUNNING_COLOR, &mode_running_color, _data_FX_MODE_RUNNING_COLOR);
   addEffect(FX_MODE_AURORA, &mode_aurora, _data_FX_MODE_AURORA);
   addEffect(FX_MODE_RUNNING_RANDOM, &mode_running_random, _data_FX_MODE_RUNNING_RANDOM);
   addEffect(FX_MODE_LARSON_SCANNER, &mode_larson_scanner, _data_FX_MODE_LARSON_SCANNER);
@@ -10265,7 +10186,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_FAIRY, &mode_fairy, _data_FX_MODE_FAIRY);
   addEffect(FX_MODE_TWO_DOTS, &mode_two_dots, _data_FX_MODE_TWO_DOTS);
   addEffect(FX_MODE_FAIRYTWINKLE, &mode_fairytwinkle, _data_FX_MODE_FAIRYTWINKLE);
-  addEffect(FX_MODE_RUNNING_DUAL, &mode_running_dual, _data_FX_MODE_RUNNING_DUAL);
+  //addEffect(FX_MODE_RUNNING_DUAL, &mode_running_dual, _data_FX_MODE_RUNNING_DUAL);
   #ifdef WLED_ENABLE_GIF
   addEffect(FX_MODE_IMAGE, &mode_image, _data_FX_MODE_IMAGE);
   #endif
@@ -10325,7 +10246,7 @@ void WS2812FX::setupEffectData() {
   //addEffect(FX_MODE_RIPPLE_RAINBOW, &mode_ripple_rainbow, _data_FX_MODE_RIPPLE_RAINBOW);
   addEffect(FX_MODE_HEARTBEAT, &mode_heartbeat, _data_FX_MODE_HEARTBEAT);
   addEffect(FX_MODE_PACIFICA, &mode_pacifica, _data_FX_MODE_PACIFICA);
-  addEffect(FX_MODE_CANDLE_MULTI, &mode_candle_multi, _data_FX_MODE_CANDLE_MULTI);
+  //addEffect(FX_MODE_CANDLE_MULTI, &mode_candle_multi, _data_FX_MODE_CANDLE_MULTI);
   //addEffect(FX_MODE_SOLID_GLITTER, &mode_solid_glitter, _data_FX_MODE_SOLID_GLITTER);
   addEffect(FX_MODE_SUNRISE, &mode_sunrise, _data_FX_MODE_SUNRISE);
   addEffect(FX_MODE_PHASED, &mode_phased, _data_FX_MODE_PHASED);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -362,14 +362,14 @@ static const char _data_FX_MODE_DYNAMIC[] PROGMEM = "Dynamic@!,!,,,,Smooth;;!";
 /*
  * effect "Dynamic" with smooth color-fading
  */
-uint16_t mode_dynamic_smooth(void) {
-  bool old = SEGMENT.check1;
-  SEGMENT.check1 = true;
-  mode_dynamic();
-  SEGMENT.check1 = old;
-  return FRAMETIME;
- }
-static const char _data_FX_MODE_DYNAMIC_SMOOTH[] PROGMEM = "Dynamic Smooth@!,!;;!";
+//uint16_t mode_dynamic_smooth(void) {
+//  bool old = SEGMENT.check1;
+//  SEGMENT.check1 = true;
+//  mode_dynamic();
+//  SEGMENT.check1 = old;
+//  return FRAMETIME;
+//}
+//static const char _data_FX_MODE_DYNAMIC_SMOOTH[] PROGMEM = "Dynamic Smooth@!,!;;!";
 
 
 /*
@@ -506,7 +506,10 @@ static uint16_t running(uint32_t color1, uint32_t color2, bool theatre = false) 
 
   for (unsigned i = 0; i < SEGLEN; i++) {
     uint32_t col = color2;
-    if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
+    if (usePalette) {
+      unsigned palIdx = SEGMENT.check1 ? (i+it)%SEGLEN : i;
+      color1 = SEGMENT.color_from_palette(palIdx, true, SEGMENT.check1, 0);
+    }
     if (theatre) {
       if ((i % width) == SEGENV.aux0) col = color1;
     } else {
@@ -531,7 +534,7 @@ static uint16_t running(uint32_t color1, uint32_t color2, bool theatre = false) 
 uint16_t mode_theater_chase(void) {
   return running(SEGCOLOR(0), SEGCOLOR(1), true);
 }
-static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size;!,!;!";
+static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size,,,,Animate palette;!,!;!;;o1=0";
 
 
 /*
@@ -541,7 +544,7 @@ static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size;!,
 uint16_t mode_theater_chase_rainbow(void) {
   return running(SEGMENT.color_wheel(SEGENV.step), SEGCOLOR(1), true);
 }
-static const char _data_FX_MODE_THEATER_CHASE_RAINBOW[] PROGMEM = "Theater Rainbow@!,Gap size;,!;!";
+static const char _data_FX_MODE_THEATER_CHASE_RAINBOW[] PROGMEM = "Theater Rainbow@!,Gap size;,!;!;;o1=0";
 
 
 /*
@@ -550,6 +553,7 @@ static const char _data_FX_MODE_THEATER_CHASE_RAINBOW[] PROGMEM = "Theater Rainb
 static uint16_t running_base(bool saw, bool dual=false) {
   unsigned x_scale = SEGMENT.intensity >> 2;
   uint32_t counter = (strip.now * SEGMENT.speed) >> 9;
+  const bool moving = SEGMENT.check1;
 
   for (unsigned i = 0; i < SEGLEN; i++) {
     unsigned a = i*x_scale - counter;
@@ -563,12 +567,13 @@ static uint16_t running_base(bool saw, bool dual=false) {
       }
       a = 255 - a;
     }
-    uint8_t s = dual ? sin_gap(a) : sin8_t(a);
-    uint32_t ca = color_blend(SEGCOLOR(1), SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0), s);
+    unsigned palIdx = moving ? (i+counter)%SEGLEN : i;
+    uint8_t s = dual ? sin_gap(a) : sin8(a);
+    uint32_t ca = color_blend(SEGCOLOR(1), SEGMENT.color_from_palette(palIdx, true, moving, 0), s);
     if (dual) {
       unsigned b = (SEGLEN-1-i)*x_scale - counter;
       uint8_t t = sin_gap(b);
-      uint32_t cb = color_blend(SEGCOLOR(1), SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 2), t);
+      uint32_t cb = color_blend(SEGCOLOR(1), SEGMENT.color_from_palette(palIdx, true, moving, 2), t);
       ca = color_blend(ca, cb, uint8_t(127));
     }
     SEGMENT.setPixelColor(i, ca);
@@ -585,7 +590,7 @@ static uint16_t running_base(bool saw, bool dual=false) {
 uint16_t mode_running_dual(void) {
   return running_base(false, true);
 }
-static const char _data_FX_MODE_RUNNING_DUAL[] PROGMEM = "Running Dual@!,Wave width;L,!,R;!";
+static const char _data_FX_MODE_RUNNING_DUAL[] PROGMEM = "Running Dual@!,Wave width,,,,Animate palette;L,!,R;!;;o1=0";
 
 
 /*
@@ -594,7 +599,7 @@ static const char _data_FX_MODE_RUNNING_DUAL[] PROGMEM = "Running Dual@!,Wave wi
 uint16_t mode_running_lights(void) {
   return running_base(false);
 }
-static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Wave width;!,!;!";
+static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Wave width,,,,Animate palette;!,!;!;;o1=0";
 
 
 /*
@@ -603,7 +608,7 @@ static const char _data_FX_MODE_RUNNING_LIGHTS[] PROGMEM = "Running@!,Wave width
 uint16_t mode_saw(void) {
   return running_base(true);
 }
-static const char _data_FX_MODE_SAW[] PROGMEM = "Saw@!,Width;!,!;!";
+static const char _data_FX_MODE_SAW[] PROGMEM = "Saw@!,Width,,,,Animate palette;!,!;!;;o1=0";
 
 
 /*
@@ -699,10 +704,10 @@ static const char _data_FX_MODE_DISSOLVE[] PROGMEM = "Dissolve@Repeat speed,Diss
 /*
  * Blink several LEDs on and then off in random colors
  */
-uint16_t mode_dissolve_random(void) {
-  return dissolve(SEGMENT.color_wheel(hw_random8()));
-}
-static const char _data_FX_MODE_DISSOLVE_RANDOM[] PROGMEM = "Dissolve Rnd@Repeat speed,Dissolve speed;,!;!";
+//uint16_t mode_dissolve_random(void) {
+//  return dissolve(SEGMENT.color_wheel(hw_random8()));
+//}
+//static const char _data_FX_MODE_DISSOLVE_RANDOM[] PROGMEM = "Dissolve Rnd@Repeat speed,Dissolve speed;,!;!";
 
 
 /*
@@ -710,11 +715,13 @@ static const char _data_FX_MODE_DISSOLVE_RANDOM[] PROGMEM = "Dissolve Rnd@Repeat
  * Inspired by www.tweaking4all.com/hardware/arduino/adruino-led-strip-effects/
  */
 uint16_t mode_sparkle(void) {
-  if (!SEGMENT.check2) for (unsigned i = 0; i < SEGLEN; i++) {
-    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 1));
-  }
   uint32_t cycleTime = 10 + (255 - SEGMENT.speed)*2;
   uint32_t it = strip.now / cycleTime;
+  const bool moving = SEGMENT.check1;
+  if (!SEGMENT.check2) for(unsigned i = 0; i < SEGLEN; i++) {
+    unsigned palIdx = moving ? (i+it)%SEGLEN : i;
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(palIdx, true, moving, 1));
+  }
   if (it != SEGENV.step)
   {
     SEGENV.aux0 = hw_random16(SEGLEN); // aux0 stores the random led index
@@ -724,7 +731,7 @@ uint16_t mode_sparkle(void) {
   SEGMENT.setPixelColor(SEGENV.aux0, SEGCOLOR(0));
   return FRAMETIME;
 }
-static const char _data_FX_MODE_SPARKLE[] PROGMEM = "Sparkle@!,,,,,,Overlay;!,!;!;;m12=0";
+static const char _data_FX_MODE_SPARKLE[] PROGMEM = "Sparkle@!,,,,,Animate palette,Overlay;!,!;!;;m12=0,01=0";
 
 
 /*
@@ -732,8 +739,12 @@ static const char _data_FX_MODE_SPARKLE[] PROGMEM = "Sparkle@!,,,,,,Overlay;!,!;
  * Inspired by www.tweaking4all.com/hardware/arduino/adruino-led-strip-effects/
  */
 uint16_t mode_flash_sparkle(void) {
+  uint32_t cycleTime = 10 + (255 - SEGMENT.speed)*2;
+  uint32_t it = strip.now / cycleTime;
+  const bool moving = SEGMENT.check1;
   if (!SEGMENT.check2) for (unsigned i = 0; i < SEGLEN; i++) {
-    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
+    unsigned palIdx = moving ? (i+it)%SEGLEN : i;
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(palIdx, true, moving, 0));
   }
 
   if (strip.now - SEGENV.aux0 > SEGENV.step) {
@@ -745,7 +756,7 @@ uint16_t mode_flash_sparkle(void) {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_FLASH_SPARKLE[] PROGMEM = "Sparkle Dark@!,!,,,,,Overlay;Bg,Fx;!;;m12=0";
+static const char _data_FX_MODE_FLASH_SPARKLE[] PROGMEM = "Sparkle Dark@!,!,,,,Animate palette,Overlay;Bg,Fx;!;;m12=0";
 
 
 /*
@@ -753,8 +764,12 @@ static const char _data_FX_MODE_FLASH_SPARKLE[] PROGMEM = "Sparkle Dark@!,!,,,,,
  * Inspired by www.tweaking4all.com/hardware/arduino/adruino-led-strip-effects/
  */
 uint16_t mode_hyper_sparkle(void) {
+  uint32_t cycleTime = 10 + (255 - SEGMENT.speed)*2;
+  uint32_t it = strip.now / cycleTime;
+  const bool moving = SEGMENT.check1;
   if (!SEGMENT.check2) for (unsigned i = 0; i < SEGLEN; i++) {
-    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
+    unsigned palIdx = moving ? (i+it)%SEGLEN : i;
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(palIdx, true, moving, 0));
   }
 
   if (strip.now - SEGENV.aux0 > SEGENV.step) {
@@ -769,15 +784,19 @@ uint16_t mode_hyper_sparkle(void) {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_HYPER_SPARKLE[] PROGMEM = "Sparkle+@!,!,,,,,Overlay;Bg,Fx;!;;m12=0";
+static const char _data_FX_MODE_HYPER_SPARKLE[] PROGMEM = "Sparkle+@!,!,,,,Animate palette,Overlay;Bg,Fx;!;;m12=0";
 
 
 /*
  * Strobe effect with different strobe count and pause, controlled by speed.
  */
 uint16_t mode_multi_strobe(void) {
+  uint32_t cycleTime = 10 + (255 - SEGMENT.speed)*2;
+  uint32_t it = strip.now / cycleTime;
+  const bool moving = SEGMENT.check1;
   for (unsigned i = 0; i < SEGLEN; i++) {
-    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 1));
+    unsigned palIdx = moving ? (i+it)%SEGLEN : i;
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(palIdx, true, moving, 1));
   }
 
   SEGENV.aux0 = 50 + 20*(uint16_t)(255-SEGMENT.speed);
@@ -799,7 +818,7 @@ uint16_t mode_multi_strobe(void) {
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_MULTI_STROBE[] PROGMEM = "Strobe Mega@!,!;!,!;!;01";
+static const char _data_FX_MODE_MULTI_STROBE[] PROGMEM = "Strobe Mega@!,!,,,,Animate palette;!,!;!;01;o1=0";
 
 
 /*
@@ -1057,8 +1076,12 @@ uint16_t mode_chase_flash(void) {
   if (SEGLEN <= 1) return mode_static();
   unsigned flash_step = SEGENV.call % ((FLASH_COUNT * 2) + 1);
 
+  uint32_t cycleTime = 10 + (255 - SEGMENT.speed)*2;
+  uint32_t it = strip.now / cycleTime;
+  const bool moving = SEGMENT.check1;
   for (unsigned i = 0; i < SEGLEN; i++) {
-    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
+    unsigned palIdx = moving ? (i+it)%SEGLEN : i;
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(palIdx, true, moving, 0));
   }
 
   unsigned delay = 10 + ((30 * (uint16_t)(255 - SEGMENT.speed)) / SEGLEN);
@@ -1077,7 +1100,7 @@ uint16_t mode_chase_flash(void) {
   }
   return delay;
 }
-static const char _data_FX_MODE_CHASE_FLASH[] PROGMEM = "Chase Flash@!;Bg,Fx;!";
+static const char _data_FX_MODE_CHASE_FLASH[] PROGMEM = "Chase Flash@!,,,,,Animate palette;Bg,Fx;!;;o1=0";
 
 
 /*
@@ -1194,12 +1217,16 @@ uint16_t mode_larson_scanner(void) {
 
   } else {
 
+    uint32_t cycleTime = 10 + (255 - SEGMENT.speed)*2;
+    uint32_t it = strip.now / cycleTime;
+    const bool moving = SEGMENT.check1;
     // paint as many pixels as needed
     for (unsigned i = SEGENV.aux1; i < index; i++) {
       unsigned j = (SEGENV.aux0) ? i : SEGLEN - 1 - i;
-      uint32_t c = SEGMENT.color_from_palette(j, true, PALETTE_SOLID_WRAP, 0);
+      unsigned palIdx = moving ? (j+it)%SEGLEN : j;
+      uint32_t c = SEGMENT.color_from_palette(palIdx, true, moving, 0);
       SEGMENT.setPixelColor(j, c);
-      if (SEGMENT.check1) {
+      if (SEGMENT.check3) {
         SEGMENT.setPixelColor(SEGLEN - 1 - j, SEGCOLOR(2) ? SEGCOLOR(2) : c);
       }
     }
@@ -1207,17 +1234,18 @@ uint16_t mode_larson_scanner(void) {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_LARSON_SCANNER[] PROGMEM = "Scanner@!,Trail,Delay,,,Dual,Bi-delay;!,!,!;!;;m12=0,c1=0";
+static const char _data_FX_MODE_LARSON_SCANNER[] PROGMEM = "Scanner@!,Trail,Delay,,,Animate palette,Bi-delay,Dual;!,!,!;!;;m12=0,c1=0,o1=0,o3=0";
 
 /*
  * Creates two Larson scanners moving in opposite directions
  * Custom mode by Keith Lord: https://github.com/kitesurfer1404/WS2812FX/blob/master/src/custom/DualLarson.h
  */
-uint16_t mode_dual_larson_scanner(void){
-  SEGMENT.check1 = true;
-  return mode_larson_scanner();
-}
-static const char _data_FX_MODE_DUAL_LARSON_SCANNER[] PROGMEM = "Scanner Dual@!,Trail,Delay,,,Dual,Bi-delay;!,!,!;!;;m12=0,c1=0";
+//uint16_t mode_dual_larson_scanner(void){
+//  SEGMENT.check3 = true;
+//  return mode_larson_scanner();
+//}
+//static const char _data_FX_MODE_DUAL_LARSON_SCANNER[] PROGMEM = "Scanner Dual@!,Trail,Delay,,,Animate palette,Bi-delay;!,!,!;!;;m12=0,c1=0,o3=1";
+
 
 /*
  * Firing comets from one end. "Lighthouse"
@@ -2144,7 +2172,7 @@ uint16_t mode_fire_2012() {
 
       // Step 4.  Map from heat cells to LED colors
       for (unsigned j = 0; j < SEGLEN; j++) {
-        SEGMENT.setPixelColor(indexToVStrip(j, stripNr), ColorFromPalette(SEGPALETTE, min(heat[j], byte(240)), 255, NOBLEND));
+        SEGMENT.setPixelColor(indexToVStrip(j, stripNr), ColorFromPalette(SEGPALETTE, heat[j], 255, LINEARBLEND_NOWRAP));
       }
     }
   };
@@ -2348,59 +2376,76 @@ uint16_t mode_meteor() {
   byte* trail = SEGENV.data;
 
   const unsigned meteorSize = 1 + SEGLEN / 20; // 5%
-  uint16_t meteorstart;
-  if(meteorSmooth) meteorstart = map((SEGENV.step >> 6 & 0xFF), 0, 255, 0, SEGLEN -1);
-  else {
-    unsigned counter = strip.now * ((SEGMENT.speed >> 2) + 8);
-    meteorstart = (counter * SEGLEN) >> 16;
-  }
+  unsigned counter = strip.now * ((SEGMENT.speed >> 2) +8);
+  uint16_t in = counter * SEGLEN >> 16;
+  const bool gradient = SEGMENT.check1;
 
   const int max = SEGMENT.palette==5 || !SEGMENT.check1 ? 240 : 255;
   // fade all leds to colors[1] in LEDs one step
   for (unsigned i = 0; i < SEGLEN; i++) {
-    uint32_t col;
-    if (hw_random8() <= 255 - SEGMENT.intensity) {
-      if(meteorSmooth) {
-        if (trail[i] > 0) {
-          int change = trail[i] + 4 - hw_random8(24); //change each time between -20 and +4
-          trail[i] = constrain(change, 0, max);
-        }
-        col = SEGMENT.check1 ? SEGMENT.color_from_palette(i, true, false, 0, trail[i]) : SEGMENT.color_from_palette(trail[i], false, true, 255);
+    if (random8() <= 255 - SEGMENT.intensity) {
+      int meteorTrailDecay = 128 + hw_random8(127);
+      trail[i] = scale8(trail[i], meteorTrailDecay);
+      int index = trail[i];
+      int idx = 255;
+      int bri = SEGMENT.palette==35 || SEGMENT.palette==36 ? 255 : trail[i];
+      if (!gradient) {
+        idx = 0;
+        index = map(i,0,SEGLEN,0,max);
+        bri = trail[i];
       }
-      else {
-        trail[i] = scale8(trail[i], 128 + hw_random8(127));
-        int index = trail[i];
-        int idx = 255;
-        int bri = SEGMENT.palette==35 || SEGMENT.palette==36 ? 255 : trail[i];
-        if (!SEGMENT.check1) {
-          idx = 0;
-          index = map(i,0,SEGLEN,0,max);
-          bri = trail[i];
-        }
-        col = SEGMENT.color_from_palette(index, false, false, idx, bri);  // full brightness for Fire
-      }
-      SEGMENT.setPixelColor(i, col);
+      SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(index, false, false, idx, bri)); // full brightness for Fire
     }
   }
 
   // draw meteor
   for (unsigned j = 0; j < meteorSize; j++) {
-    unsigned index = (meteorstart + j) % SEGLEN;
-    if(meteorSmooth) {
-        trail[index] = max;
-        uint32_t col = SEGMENT.check1 ? SEGMENT.color_from_palette(index, true, false, 0, trail[index]) : SEGMENT.color_from_palette(trail[index], false, true, 255);
-        SEGMENT.setPixelColor(index, col);
+    int index = (in + j) % SEGLEN;
+    int idx = 255;
+    int i = trail[index] = max;
+    if (!gradient) {
+      i = map(index,0,SEGLEN,0,max);
+      idx = 0;
     }
-    else{
-      int idx = 255;
-      int i = trail[index] = max;
-      if (!SEGMENT.check1) {
-        i = map(index,0,SEGLEN,0,max);
-        idx = 0;
-      }
-      uint32_t col = SEGMENT.color_from_palette(i, false, false, idx, 255); // full brightness
-      SEGMENT.setPixelColor(index, col);
+    SEGMENT.setPixelColor(index, SEGMENT.color_from_palette(i, false, false, idx, 255)); // full brightness
+  }
+
+  return FRAMETIME;
+}
+static const char _data_FX_MODE_METEOR[] PROGMEM = "Meteor@!,Trail,,,,Gradient;!;!;1";
+
+
+// smooth meteor effect
+// send a meteor from begining to to the end of the strip with a trail that randomly decays.
+// adapted from https://www.tweaking4all.com/hardware/arduino/adruino-led-strip-effects/#LEDStripEffectMeteorRain
+uint16_t mode_meteor_smooth() {
+  if (SEGLEN <= 1) return mode_static();
+  if (!SEGENV.allocateData(SEGLEN)) return mode_static(); //allocation failed
+
+  byte* trail = SEGENV.data;
+
+  const unsigned meteorSize = 1+ SEGLEN / 20; // 5%
+  uint16_t in = map((SEGENV.step >> 6 & 0xFF), 0, 255, 0, SEGLEN -1);
+  const bool gradient = SEGMENT.check1;
+
+  const int max = SEGMENT.palette==5 || !gradient ? 240 : 255;
+  // fade all leds to colors[1] in LEDs one step
+  for (unsigned i = 0; i < SEGLEN; i++) {
+    if (/*trail[i] != 0 &&*/ hw_random8() <= 255 - SEGMENT.intensity) {
+      int change = trail[i] + 4 - hw_random8(24); //change each time between -20 and +4
+      trail[i] = constrain(change, 0, max);
+      SEGMENT.setPixelColor(i, gradient ? SEGMENT.color_from_palette(i, true, false, 0, trail[i]) : SEGMENT.color_from_palette(trail[i], false, true, 255));
     }
+  }
+
+  // draw meteor
+  for (unsigned j = 0; j < meteorSize; j++) {
+    unsigned index = in + j;
+    if (index >= SEGLEN) {
+      index -= SEGLEN;
+    }
+    trail[index] = max;
+    SEGMENT.setPixelColor(index, gradient ? SEGMENT.color_from_palette(index, true, false, 0, trail[index]) : SEGMENT.color_from_palette(trail[index], false, true, 255));
   }
 
   SEGENV.step += SEGMENT.speed +1;
@@ -2513,19 +2558,7 @@ static uint16_t ripple_base(uint8_t blurAmount = 0) {
 
 uint16_t mode_ripple(void) {
   if (SEGLEN <= 1) return mode_static();
-  if(SEGMENT.custom1 || SEGMENT.check2) // blur or overlay
-    SEGMENT.fade_out(250);
-  else
-    SEGMENT.fill(SEGCOLOR(1));
-
-  return ripple_base(SEGMENT.custom1>>1);
-}
-static const char _data_FX_MODE_RIPPLE[] PROGMEM = "Ripple@!,Wave #,Blur,,,,Overlay;,!;!;12;c1=0";
-
-
-uint16_t mode_ripple_rainbow(void) {
-  if (SEGLEN <= 1) return mode_static();
-  if (SEGENV.call ==0) {
+  if (SEGENV.call == 0) {
     SEGENV.aux0 = hw_random8();
     SEGENV.aux1 = hw_random8();
   }
@@ -2536,10 +2569,30 @@ uint16_t mode_ripple_rainbow(void) {
   } else {
     SEGENV.aux0--;
   }
-  SEGMENT.fill(color_blend(SEGMENT.color_wheel(SEGENV.aux0),BLACK,uint8_t(235)));
+  if (!SEGMENT.check2) SEGMENT.fill(SEGMENT.check1 ? color_blend(SEGMENT.color_wheel(SEGENV.aux0),BLACK,uint8_t(240)) : SEGCOLOR(1));
+  else                 SEGMENT.fade_out(250);
   return ripple_base();
 }
-static const char _data_FX_MODE_RIPPLE_RAINBOW[] PROGMEM = "Ripple Rainbow@!,Wave #;;!;12";
+static const char _data_FX_MODE_RIPPLE[] PROGMEM = "Ripple@!,Waves,,,,Palette BG,Overlay;,!;!;12;o1=0";
+
+
+//uint16_t mode_ripple_rainbow(void) {
+//  if (SEGLEN <= 1) return mode_static();
+//  if (SEGENV.call ==0) {
+//    SEGENV.aux0 = hw_random8();
+//    SEGENV.aux1 = hw_random8();
+//  }
+//  if (SEGENV.aux0 == SEGENV.aux1) {
+//    SEGENV.aux1 = hw_random8();
+//  } else if (SEGENV.aux1 > SEGENV.aux0) {
+//    SEGENV.aux0++;
+//  } else {
+//    SEGENV.aux0--;
+//  }
+//  SEGMENT.fill(color_blend(SEGMENT.color_wheel(SEGENV.aux0),BLACK,uint8_t(235)));
+//  return ripple_base();
+//}
+//static const char _data_FX_MODE_RIPPLE_RAINBOW[] PROGMEM = "Ripple Rainbow@!,Waves;;!;12";
 
 
 //  TwinkleFOX by Mark Kriegsman: https://gist.github.com/kriegsman/756ea6dcae8e30845b5a
@@ -3119,8 +3172,10 @@ static const char _data_FX_MODE_ROLLINGBALLS[] PROGMEM = "Rolling Balls@!,# of b
 /*
 * Sinelon stolen from FASTLED examples
 */
-static uint16_t sinelon_base(bool dual, bool rainbow=false) {
+uint16_t mode_sinelon() {
   if (SEGLEN <= 1) return mode_static();
+  const bool rainbow = SEGMENT.check1;
+  const bool dual    = SEGMENT.check3;
   SEGMENT.fade_out(SEGMENT.intensity);
   unsigned pos = beatsin16_t(SEGMENT.speed/10,0,SEGLEN-1);
   if (SEGENV.call == 0) SEGENV.aux0 = pos;
@@ -3153,29 +3208,21 @@ static uint16_t sinelon_base(bool dual, bool rainbow=false) {
   return FRAMETIME;
 }
 
+//uint16_t mode_sinelon(void) {
+//  return sinelon_base(false);
+//}
+static const char _data_FX_MODE_SINELON[] PROGMEM = "Sinelon@!,Trail,,,,Rainbow,,Dual;!,!,!;!";
 
-uint16_t mode_sinelon(void) {
-  return sinelon_base(false);
-}
-static const char _data_FX_MODE_SINELON[] PROGMEM = "Sinelon@!,Trail;!,!,!;!";
+//uint16_t mode_sinelon_dual(void) {
+//  return sinelon_base(true);
+//}
+//static const char _data_FX_MODE_SINELON_DUAL[] PROGMEM = "Sinelon Dual@!,Trail;!,!,!;!";
 
+//uint16_t mode_sinelon_rainbow(void) {
+//  return sinelon_base(false, true);
+//}
+//static const char _data_FX_MODE_SINELON_RAINBOW[] PROGMEM = "Sinelon Rainbow@!,Trail;,,!;!";
 
-uint16_t mode_sinelon_dual(void) {
-  return sinelon_base(true);
-}
-static const char _data_FX_MODE_SINELON_DUAL[] PROGMEM = "Sinelon Dual@!,Trail;!,!,!;!";
-
-
-uint16_t mode_sinelon_rainbow(void) {
-  return sinelon_base(false, true);
-}
-static const char _data_FX_MODE_SINELON_RAINBOW[] PROGMEM = "Sinelon Rainbow@!,Trail;,,!;!";
-
-
-// utility function that will add random glitter to SEGMENT
-void glitter_base(uint8_t intensity, uint32_t col = ULTRAWHITE) {
-  if (intensity > hw_random8()) SEGMENT.setPixelColor(hw_random16(SEGLEN), col);
-}
 
 //Glitter with palette background, inspired by https://gist.github.com/kriegsman/062e10f7f07ba8518af6
 uint16_t mode_glitter()
@@ -3183,31 +3230,30 @@ uint16_t mode_glitter()
   if (!SEGMENT.check2) { // use "* Color 1" palette for solid background (replacing "Solid glitter")
     unsigned counter = 0;
     if (SEGMENT.speed != 0) {
+      // animate palette
       counter = (strip.now * ((SEGMENT.speed >> 3) +1)) & 0xFFFF;
       counter = counter >> 8;
     }
-
-    bool noWrap = (strip.paletteBlend == 2 || (strip.paletteBlend == 0 && SEGMENT.speed == 0));
     for (unsigned i = 0; i < SEGLEN; i++) {
       unsigned colorIndex = (i * 255 / SEGLEN) - counter;
-      if (noWrap) colorIndex = map(colorIndex, 0, 255, 0, 240); //cut off blend at palette "end"
       SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(colorIndex, false, true, 255));
     }
   }
-  glitter_base(SEGMENT.intensity, SEGCOLOR(2) ? SEGCOLOR(2) : ULTRAWHITE);
+  if (SEGMENT.intensity > hw_random8()) SEGMENT.setPixelColor(hw_random16(SEGLEN), SEGCOLOR(2) ? SEGCOLOR(2) : ULTRAWHITE);
   return FRAMETIME;
 }
 static const char _data_FX_MODE_GLITTER[] PROGMEM = "Glitter@!,!,,,,,Overlay;,,Glitter color;!;;pal=11,m12=0"; //pixels
 
 
 //Solid colour background with glitter (can be replaced by Glitter)
-uint16_t mode_solid_glitter()
-{
-  SEGMENT.fill(SEGCOLOR(0));
-  glitter_base(SEGMENT.intensity, SEGCOLOR(2) ? SEGCOLOR(2) : ULTRAWHITE);
-  return FRAMETIME;
-}
-static const char _data_FX_MODE_SOLID_GLITTER[] PROGMEM = "Solid Glitter@,!;Bg,,Glitter color;;;m12=0";
+//uint16_t mode_solid_glitter()
+//{
+//  SEGMENT.fill(SEGCOLOR(0));
+//  glitter_base(SEGMENT.intensity, SEGCOLOR(2) ? SEGCOLOR(2) : ULTRAWHITE);
+//  return FRAMETIME;
+//}
+//static const char _data_FX_MODE_SOLID_GLITTER[] PROGMEM = "Solid Glitter@,!;Bg,,Glitter color;;;m12=0";
+
 
 //each needs 20 bytes
 //Spark type is used for popcorn, 1D fireworks, and drip
@@ -3764,11 +3810,12 @@ uint16_t mode_tetrix(void) {
   // the following functions will not work on virtual strips: fill(), fade_out(), fadeToBlack(), blur()
   struct virtualStrip {
     static void runStrip(size_t stripNr, Tetris *drop) {
+      const bool oneColor = SEGMENT.check1;
       // initialize dropping on first call or segment full
       if (SEGENV.call == 0) {
         drop->stack = 0;                  // reset brick stack size
-        drop->step = strip.now + 2000;     // start by fading out strip
-        if (SEGMENT.check1) drop->col = 0;// use only one color from palette
+        drop->step = strip.now + 2000;    // start by fading out strip
+        if (oneColor) drop->col = 0;      // use only one color from palette
       }
 
       if (drop->step == 0) {              // init brick
@@ -3779,7 +3826,7 @@ uint16_t mode_tetrix(void) {
         speed = map(speed, 1, 255, 5000, 250); // time taken for full (SEGLEN) drop
         drop->speed = float(SEGLEN * FRAMETIME) / float(speed); // set speed
         drop->pos   = SEGLEN;             // start at end of segment (no need to subtract 1)
-        if (!SEGMENT.check1) drop->col = hw_random8(0,15)<<4;   // limit color choices so there is enough HUE gap
+        if (!oneColor) drop->col = hw_random8(0,15)<<4;   // limit color choices so there is enough HUE gap
         drop->step  = 1;                  // drop state (0 init, 1 forming, 2 falling)
         drop->brick = (SEGMENT.intensity ? (SEGMENT.intensity>>5)+1 : hw_random8(1,5)) * (1+(SEGLEN>>6));  // size of brick
       }
@@ -3813,7 +3860,7 @@ uint16_t mode_tetrix(void) {
         } else {
           drop->stack = 0;                // reset brick stack size
           drop->step = 0;                 // proceed with next brick
-          if (SEGMENT.check1) drop->col += 8;   // gradually increase palette index
+          if (oneColor) drop->col += 8;   // gradually increase palette index
         }
       }
     }
@@ -3861,6 +3908,7 @@ uint16_t mode_percent(void) {
   percent = constrain(percent, 0, 200);
   unsigned active_leds = (percent < 100) ? roundf(SEGLEN * percent / 100.0f)
                                          : roundf(SEGLEN * (200 - percent) / 100.0f);
+  const bool oneColor = SEGMENT.check1;
 
   unsigned size = (1 + ((SEGMENT.speed * SEGLEN) >> 11));
   if (SEGMENT.speed == 255) size = 255;
@@ -3868,7 +3916,7 @@ uint16_t mode_percent(void) {
   if (percent <= 100) {
     for (unsigned i = 0; i < SEGLEN; i++) {
     	if (i < SEGENV.aux1) {
-        if (SEGMENT.check1)
+        if (oneColor)
           SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(map(percent,0,100,0,255), false, false, 0));
         else
           SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
@@ -3883,7 +3931,7 @@ uint16_t mode_percent(void) {
         SEGMENT.setPixelColor(i, SEGCOLOR(1));
     	}
     	else {
-        if (SEGMENT.check1)
+        if (oneColor)
           SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(map(percent,100,200,255,0), false, false, 0));
         else
           SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
@@ -4819,7 +4867,7 @@ uint16_t mode_wavesins(void) {
     uint8_t bri = sin8_t(strip.now/4 + i * SEGMENT.intensity);
     uint8_t index = beatsin8_t(SEGMENT.speed, SEGMENT.custom1, SEGMENT.custom1+SEGMENT.custom2, 0, i * (SEGMENT.custom3<<3)); // custom3 is reduced resolution slider
     //SEGMENT.setPixelColor(i, ColorFromPalette(SEGPALETTE, index, bri, LINEARBLEND));
-    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(index, false, PALETTE_SOLID_WRAP, 0, bri));
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(index, false, true, 0, bri));
   }
 
   return FRAMETIME;
@@ -4862,20 +4910,21 @@ uint16_t mode_2DBlackHole(void) {            // By: Stepko https://editor.soulma
   const int cols = SEG_W;
   const int rows = SEG_H;
   int x, y;
+  const bool oneColor = SEGMENT.check1;
 
   SEGMENT.fadeToBlackBy(16 + (SEGMENT.speed>>3)); // create fading trails
   unsigned long t = strip.now/128;                 // timebase
   // outer stars
   for (size_t i = 0; i < 8; i++) {
-    x = beatsin8_t(SEGMENT.custom1>>3,   0, cols - 1, 0, ((i % 2) ? 128 : 0) + t * i);
-    y = beatsin8_t(SEGMENT.intensity>>3, 0, rows - 1, 0, ((i % 2) ? 192 : 64) + t * i);
-    SEGMENT.addPixelColorXY(x, y, SEGMENT.color_from_palette(i*32, false, PALETTE_SOLID_WRAP, SEGMENT.check1?0:255));
+    x = beatsin8(SEGMENT.custom1>>3,   0, cols - 1, 0, ((i % 2) ? 128 : 0) + t * i);
+    y = beatsin8(SEGMENT.intensity>>3, 0, rows - 1, 0, ((i % 2) ? 192 : 64) + t * i);
+    SEGMENT.addPixelColorXY(x, y, SEGMENT.color_from_palette(i*32, false, PALETTE_SOLID_WRAP, oneColor?0:255));
   }
   // inner stars
   for (size_t i = 0; i < 4; i++) {
-    x = beatsin8_t(SEGMENT.custom2>>3, cols/4, cols - 1 - cols/4, 0, ((i % 2) ? 128 : 0) + t * i);
-    y = beatsin8_t(SEGMENT.custom3   , rows/4, rows - 1 - rows/4, 0, ((i % 2) ? 192 : 64) + t * i);
-    SEGMENT.addPixelColorXY(x, y, SEGMENT.color_from_palette(255-i*64, false, PALETTE_SOLID_WRAP, SEGMENT.check1?0:255));
+    x = beatsin8(SEGMENT.custom2>>3, cols/4, cols - 1 - cols/4, 0, ((i % 2) ? 128 : 0) + t * i);
+    y = beatsin8(SEGMENT.custom3   , rows/4, rows - 1 - rows/4, 0, ((i % 2) ? 192 : 64) + t * i);
+    SEGMENT.addPixelColorXY(x, y, SEGMENT.color_from_palette(255-i*64, false, PALETTE_SOLID_WRAP, oneColor?0:255));
   }
   // central white dot
   SEGMENT.setPixelColorXY(cols/2, rows/2, WHITE);
@@ -4900,8 +4949,8 @@ uint16_t mode_2DColoredBursts() {              // By: ldirko   https://editor.so
     SEGENV.aux0 = 0; // start with red hue
   }
 
-  bool dot = SEGMENT.check3;
-  bool grad = SEGMENT.check1;
+  const bool dot  = SEGMENT.check3;
+  const bool grad = SEGMENT.check1;
 
   byte numLines = SEGMENT.intensity/16 + 1;
 
@@ -10183,7 +10232,8 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_SAW, &mode_saw, _data_FX_MODE_SAW);
   addEffect(FX_MODE_TWINKLE, &mode_twinkle, _data_FX_MODE_TWINKLE);
   addEffect(FX_MODE_DISSOLVE, &mode_dissolve, _data_FX_MODE_DISSOLVE);
-  addEffect(FX_MODE_DISSOLVE_RANDOM, &mode_dissolve_random, _data_FX_MODE_DISSOLVE_RANDOM);
+  //addEffect(FX_MODE_DISSOLVE_RANDOM, &mode_dissolve_random, _data_FX_MODE_DISSOLVE_RANDOM);
+  addEffect(FX_MODE_SPARKLE, &mode_sparkle, _data_FX_MODE_SPARKLE);
   addEffect(FX_MODE_FLASH_SPARKLE, &mode_flash_sparkle, _data_FX_MODE_FLASH_SPARKLE);
   addEffect(FX_MODE_HYPER_SPARKLE, &mode_hyper_sparkle, _data_FX_MODE_HYPER_SPARKLE);
   addEffect(FX_MODE_STROBE, &mode_strobe, _data_FX_MODE_STROBE);
@@ -10224,7 +10274,8 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_TRICOLOR_FADE, &mode_tricolor_fade, _data_FX_MODE_TRICOLOR_FADE);
   addEffect(FX_MODE_LIGHTNING, &mode_lightning, _data_FX_MODE_LIGHTNING);
   addEffect(FX_MODE_ICU, &mode_icu, _data_FX_MODE_ICU);
-  addEffect(FX_MODE_DUAL_LARSON_SCANNER, &mode_dual_larson_scanner, _data_FX_MODE_DUAL_LARSON_SCANNER);
+  addEffect(FX_MODE_MULTI_COMET, &mode_multi_comet, _data_FX_MODE_MULTI_COMET);
+  //addEffect(FX_MODE_DUAL_LARSON_SCANNER, &mode_dual_larson_scanner, _data_FX_MODE_DUAL_LARSON_SCANNER);
   addEffect(FX_MODE_RANDOM_CHASE, &mode_random_chase, _data_FX_MODE_RANDOM_CHASE);
   addEffect(FX_MODE_OSCILLATE, &mode_oscillate, _data_FX_MODE_OSCILLATE);
   addEffect(FX_MODE_JUGGLE, &mode_juggle, _data_FX_MODE_JUGGLE);
@@ -10265,14 +10316,17 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_POPCORN, &mode_popcorn, _data_FX_MODE_POPCORN);
   addEffect(FX_MODE_DRIP, &mode_drip, _data_FX_MODE_DRIP);
   addEffect(FX_MODE_SINELON, &mode_sinelon, _data_FX_MODE_SINELON);
-  addEffect(FX_MODE_SINELON_DUAL, &mode_sinelon_dual, _data_FX_MODE_SINELON_DUAL);
-  addEffect(FX_MODE_SINELON_RAINBOW, &mode_sinelon_rainbow, _data_FX_MODE_SINELON_RAINBOW);
+  //addEffect(FX_MODE_SINELON_DUAL, &mode_sinelon_dual, _data_FX_MODE_SINELON_DUAL);
+  //addEffect(FX_MODE_SINELON_RAINBOW, &mode_sinelon_rainbow, _data_FX_MODE_SINELON_RAINBOW);
+  addEffect(FX_MODE_POPCORN, &mode_popcorn, _data_FX_MODE_POPCORN);
+  addEffect(FX_MODE_DRIP, &mode_drip, _data_FX_MODE_DRIP);
   addEffect(FX_MODE_PLASMA, &mode_plasma, _data_FX_MODE_PLASMA);
   addEffect(FX_MODE_PERCENT, &mode_percent, _data_FX_MODE_PERCENT);
-  addEffect(FX_MODE_RIPPLE_RAINBOW, &mode_ripple_rainbow, _data_FX_MODE_RIPPLE_RAINBOW);
+  //addEffect(FX_MODE_RIPPLE_RAINBOW, &mode_ripple_rainbow, _data_FX_MODE_RIPPLE_RAINBOW);
   addEffect(FX_MODE_HEARTBEAT, &mode_heartbeat, _data_FX_MODE_HEARTBEAT);
   addEffect(FX_MODE_PACIFICA, &mode_pacifica, _data_FX_MODE_PACIFICA);
   addEffect(FX_MODE_CANDLE_MULTI, &mode_candle_multi, _data_FX_MODE_CANDLE_MULTI);
+  //addEffect(FX_MODE_SOLID_GLITTER, &mode_solid_glitter, _data_FX_MODE_SOLID_GLITTER);
   addEffect(FX_MODE_SUNRISE, &mode_sunrise, _data_FX_MODE_SUNRISE);
   addEffect(FX_MODE_PHASED, &mode_phased, _data_FX_MODE_PHASED);
   addEffect(FX_MODE_TWINKLEUP, &mode_twinkleup, _data_FX_MODE_TWINKLEUP);
@@ -10284,7 +10338,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_WASHING_MACHINE, &mode_washing_machine, _data_FX_MODE_WASHING_MACHINE);
   addEffect(FX_MODE_BLENDS, &mode_blends, _data_FX_MODE_BLENDS);
   addEffect(FX_MODE_TV_SIMULATOR, &mode_tv_simulator, _data_FX_MODE_TV_SIMULATOR);
-  addEffect(FX_MODE_DYNAMIC_SMOOTH, &mode_dynamic_smooth, _data_FX_MODE_DYNAMIC_SMOOTH);
+  //addEffect(FX_MODE_DYNAMIC_SMOOTH, &mode_dynamic_smooth, _data_FX_MODE_DYNAMIC_SMOOTH);
 
   // --- 1D audio effects ---
   addEffect(FX_MODE_PIXELS, &mode_pixels, _data_FX_MODE_PIXELS);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -526,7 +526,7 @@ static uint16_t running_base(bool saw) {
       a = 255 - a;
     }
     unsigned palIdx = moving ? (i+counter)%SEGLEN : i;
-    uint8_t s = dual ? sin_gap(a) : sin8(a);
+    uint8_t s = dual ? sin_gap(a) : sin8_t(a);
     uint32_t ca = color_blend(SEGCOLOR(1), SEGMENT.color_from_palette(palIdx, true, moving, 0), s);
     if (dual) {
       unsigned b = (SEGLEN-1-i)*x_scale - counter;
@@ -4829,14 +4829,14 @@ uint16_t mode_2DBlackHole(void) {            // By: Stepko https://editor.soulma
   unsigned long t = strip.now/128;                 // timebase
   // outer stars
   for (size_t i = 0; i < 8; i++) {
-    x = beatsin8(SEGMENT.custom1>>3,   0, cols - 1, 0, ((i % 2) ? 128 : 0) + t * i);
-    y = beatsin8(SEGMENT.intensity>>3, 0, rows - 1, 0, ((i % 2) ? 192 : 64) + t * i);
+    x = beatsin8_t(SEGMENT.custom1>>3,   0, cols - 1, 0, ((i % 2) ? 128 : 0) + t * i);
+    y = beatsin8_t(SEGMENT.intensity>>3, 0, rows - 1, 0, ((i % 2) ? 192 : 64) + t * i);
     SEGMENT.addPixelColorXY(x, y, SEGMENT.color_from_palette(i*32, false, PALETTE_SOLID_WRAP, oneColor?0:255));
   }
   // inner stars
   for (size_t i = 0; i < 4; i++) {
-    x = beatsin8(SEGMENT.custom2>>3, cols/4, cols - 1 - cols/4, 0, ((i % 2) ? 128 : 0) + t * i);
-    y = beatsin8(SEGMENT.custom3   , rows/4, rows - 1 - rows/4, 0, ((i % 2) ? 192 : 64) + t * i);
+    x = beatsin8_t(SEGMENT.custom2>>3, cols/4, cols - 1 - cols/4, 0, ((i % 2) ? 128 : 0) + t * i);
+    y = beatsin8_t(SEGMENT.custom3   , rows/4, rows - 1 - rows/4, 0, ((i % 2) ? 192 : 64) + t * i);
     SEGMENT.addPixelColorXY(x, y, SEGMENT.color_from_palette(255-i*64, false, PALETTE_SOLID_WRAP, oneColor?0:255));
   }
   // central white dot

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1527,7 +1527,7 @@ static const char _data_FX_MODE_FAIRYTWINKLE[] PROGMEM = "Fairytwinkle@!,!;!,!;!
 /*
  * Tricolor chase function
  */
-uint16_t tricolor_chase(uint32_t color1, uint32_t color2) {
+uint16_t mode_tricolor_chase(void) {
   uint32_t cycleTime = 50 + ((255 - SEGMENT.speed)<<1);
   uint32_t it = strip.now / cycleTime;  // iterator
   unsigned width = (1 + (SEGMENT.intensity>>4)); // value of 1-16 for each colour
@@ -1536,21 +1536,13 @@ uint16_t tricolor_chase(uint32_t color1, uint32_t color2) {
   for (unsigned i = 0; i < SEGLEN; i++, index++) {
     if (index > (width*3)-1) index = 0;
 
-    uint32_t color = color1;
+    uint32_t color = SEGCOLOR(2);
     if (index > (width<<1)-1) color = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 1);
-    else if (index > width-1) color = color2;
+    else if (index > width-1) color = SEGCOLOR(0);
 
     SEGMENT.setPixelColor(SEGLEN - i -1, color);
   }
   return FRAMETIME;
-}
-
-
-/*
- * Tricolor chase mode
- */
-uint16_t mode_tricolor_chase(void) {
-  return tricolor_chase(SEGCOLOR(2), SEGCOLOR(0));
 }
 static const char _data_FX_MODE_TRICOLOR_CHASE[] PROGMEM = "Chase 3@!,Size;1,2,3;!";
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -146,7 +146,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 //#define FX_MODE_DUAL_SCAN               11  // removed in 0.16, use Scan with check
 #define FX_MODE_FADE                    12
 #define FX_MODE_THEATER_CHASE           13
-//#define FX_MODE_THEATER_CHASE_RAINBOW   14  // removed in 0.16, use Theater with check
+//#define FX_MODE_THEATER_CHASE_RAINBOW   14  // removed in 0.16, use Theater with check 1
 #define FX_MODE_RUNNING_LIGHTS          15
 //#define FX_MODE_SAW                     16  // removed in 0.16, use Running with with check 3
 #define FX_MODE_TWINKLE                 17
@@ -169,7 +169,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_COLORFUL                34
 #define FX_MODE_TRAFFIC_LIGHT           35
 #define FX_MODE_COLOR_SWEEP_RANDOM      36
-//#define FX_MODE_RUNNING_COLOR           37  // removed in 0.16, use Theater
+//#define FX_MODE_RUNNING_COLOR           37  // removed in 0.16, use Theater without check 3
 #define FX_MODE_AURORA                  38
 #define FX_MODE_RUNNING_RANDOM          39
 #define FX_MODE_LARSON_SCANNER          40
@@ -231,7 +231,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_DRIP                    96
 #define FX_MODE_PLASMA                  97
 #define FX_MODE_PERCENT                 98
-//#define FX_MODE_RIPPLE_RAINBOW          99  // removed in 0.16, use Sinelon with check 1
+//#define FX_MODE_RIPPLE_RAINBOW          99  // removed in 0.16, use Ripple with check 1
 #define FX_MODE_HEARTBEAT              100
 #define FX_MODE_PACIFICA               101
 //#define FX_MODE_CANDLE_MULTI           102  // removed in 0.16, use Candle with check 3

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -151,7 +151,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_SAW                     16
 #define FX_MODE_TWINKLE                 17
 #define FX_MODE_DISSOLVE                18
-#define FX_MODE_DISSOLVE_RANDOM         19  // candidate for removal (use Dissolve with with check 3)
+//#define FX_MODE_DISSOLVE_RANDOM         19  // candidate for removal (use Dissolve with with check 3)
 #define FX_MODE_SPARKLE                 20
 #define FX_MODE_FLASH_SPARKLE           21
 #define FX_MODE_HYPER_SPARKLE           22
@@ -192,7 +192,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_LIGHTNING               57
 #define FX_MODE_ICU                     58
 #define FX_MODE_MULTI_COMET             59
-#define FX_MODE_DUAL_LARSON_SCANNER     60  // candidate for removal (use Scanner with with check 1)
+//#define FX_MODE_DUAL_LARSON_SCANNER     60  // candidate for removal (use Scanner with with check 1)
 #define FX_MODE_RANDOM_CHASE            61
 #define FX_MODE_OSCILLATE               62
 #define FX_MODE_PRIDE_2015              63
@@ -225,17 +225,17 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_EXPLODING_FIREWORKS     90
 #define FX_MODE_BOUNCINGBALLS           91
 #define FX_MODE_SINELON                 92
-#define FX_MODE_SINELON_DUAL            93
-#define FX_MODE_SINELON_RAINBOW         94
+//#define FX_MODE_SINELON_DUAL            93  // candidate for removal (use sinelon)
+//#define FX_MODE_SINELON_RAINBOW         94  // candidate for removal (use sinelon)
 #define FX_MODE_POPCORN                 95
 #define FX_MODE_DRIP                    96
 #define FX_MODE_PLASMA                  97
 #define FX_MODE_PERCENT                 98
-#define FX_MODE_RIPPLE_RAINBOW          99
+//#define FX_MODE_RIPPLE_RAINBOW          99  // candidate for removal (use ripple)
 #define FX_MODE_HEARTBEAT              100
 #define FX_MODE_PACIFICA               101
 #define FX_MODE_CANDLE_MULTI           102
-#define FX_MODE_SOLID_GLITTER          103  // candidate for removal (use glitter)
+//#define FX_MODE_SOLID_GLITTER          103  // candidate for removal (use glitter)
 #define FX_MODE_SUNRISE                104
 #define FX_MODE_PHASED                 105
 #define FX_MODE_TWINKLEUP              106
@@ -249,7 +249,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_2DPLASMAROTOZOOM       114 // was Candy Cane prior to 0.14 (use Chase 2)
 #define FX_MODE_BLENDS                 115
 #define FX_MODE_TV_SIMULATOR           116
-#define FX_MODE_DYNAMIC_SMOOTH         117 // candidate for removal (check3 in dynamic)
+//#define FX_MODE_DYNAMIC_SMOOTH         117 // candidate for removal (check3 in dynamic)
 
 // new 0.14 2D effects
 #define FX_MODE_2DSPACESHIPS           118 //gap fill

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -143,16 +143,16 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_RAINBOW                  8
 #define FX_MODE_RAINBOW_CYCLE            9
 #define FX_MODE_SCAN                    10
-//#define FX_MODE_DUAL_SCAN               11  // candidate for removal (use Scan)
+//#define FX_MODE_DUAL_SCAN               11  // removed in 0.16, use Scan with check
 #define FX_MODE_FADE                    12
 #define FX_MODE_THEATER_CHASE           13
-//#define FX_MODE_THEATER_CHASE_RAINBOW   14  // candidate for removal (use Theater)
+//#define FX_MODE_THEATER_CHASE_RAINBOW   14  // removed in 0.16, use Theater with check
 #define FX_MODE_RUNNING_LIGHTS          15
-#define FX_MODE_SAW                     16
+//#define FX_MODE_SAW                     16  // removed in 0.16, use Running with with check 3
 #define FX_MODE_TWINKLE                 17
 #define FX_MODE_DISSOLVE                18
-//#define FX_MODE_DISSOLVE_RANDOM         19  // candidate for removal (use Dissolve with with check 3)
-#define FX_MODE_SPARKLE                 20
+//#define FX_MODE_DISSOLVE_RANDOM         19  // removed in 0.16, use Dissolve with with check 3
+#define FX_MODE_SPARKLE                 20  // alternative: PS Sparkler
 #define FX_MODE_FLASH_SPARKLE           21
 #define FX_MODE_HYPER_SPARKLE           22
 #define FX_MODE_STROBE                  23
@@ -169,7 +169,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_COLORFUL                34
 #define FX_MODE_TRAFFIC_LIGHT           35
 #define FX_MODE_COLOR_SWEEP_RANDOM      36
-//#define FX_MODE_RUNNING_COLOR           37  // candidate for removal (use Theater)
+//#define FX_MODE_RUNNING_COLOR           37  // removed in 0.16, use Theater
 #define FX_MODE_AURORA                  38
 #define FX_MODE_RUNNING_RANDOM          39
 #define FX_MODE_LARSON_SCANNER          40
@@ -180,25 +180,25 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_FIRE_FLICKER            45
 #define FX_MODE_GRADIENT                46
 #define FX_MODE_LOADING                 47
-#define FX_MODE_ROLLINGBALLS            48  //was Police before 0.14
+#define FX_MODE_ROLLINGBALLS            48  // alternative: PS Pinball with checkmark "rolling"
 #define FX_MODE_FAIRY                   49  //was Police All prior to 0.13.0-b6 (use "Two Dots" with Red/Blue and full intensity)
 #define FX_MODE_TWO_DOTS                50
 #define FX_MODE_FAIRYTWINKLE            51  //was Two Areas prior to 0.13.0-b6 (use "Two Dots" with full intensity)
-//#define FX_MODE_RUNNING_DUAL            52  // candidate for removal (use Running)
+//#define FX_MODE_RUNNING_DUAL            52  // removed in 0.16, use Running with with check 2
 #define FX_MODE_IMAGE                   53
 #define FX_MODE_TRICOLOR_CHASE          54
 #define FX_MODE_TRICOLOR_WIPE           55
 #define FX_MODE_TRICOLOR_FADE           56
 #define FX_MODE_LIGHTNING               57
 #define FX_MODE_ICU                     58
-#define FX_MODE_MULTI_COMET             59
-//#define FX_MODE_DUAL_LARSON_SCANNER     60  // candidate for removal (use Scanner with with check 1)
+#define FX_MODE_MULTI_COMET             59  // alternative: PS Pinball with gravity set to 0
+//#define FX_MODE_DUAL_LARSON_SCANNER     60  // removed in 0.16, use Scanner with check 3
 #define FX_MODE_RANDOM_CHASE            61
 #define FX_MODE_OSCILLATE               62
 #define FX_MODE_PRIDE_2015              63
 #define FX_MODE_JUGGLE                  64
 #define FX_MODE_PALETTE                 65
-#define FX_MODE_FIRE_2012               66
+#define FX_MODE_FIRE_2012               66  // alternative: PS Fire (1D and 2D)
 #define FX_MODE_COLORWAVES              67
 #define FX_MODE_BPM                     68
 #define FX_MODE_FILLNOISE8              69
@@ -219,23 +219,23 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_TRI_STATIC_PATTERN      84
 #define FX_MODE_SPOTS                   85
 #define FX_MODE_SPOTS_FADE              86
-#define FX_MODE_GLITTER                 87
+#define FX_MODE_GLITTER                 87  // alternative: PS Sparkler
 #define FX_MODE_CANDLE                  88
-#define FX_MODE_STARBURST               89
-#define FX_MODE_EXPLODING_FIREWORKS     90
+#define FX_MODE_STARBURST               89  // alternative: PS Starburst
+#define FX_MODE_EXPLODING_FIREWORKS     90  // alternative: PS Fireworks (1D and 2D)
 #define FX_MODE_BOUNCINGBALLS           91
 #define FX_MODE_SINELON                 92
-//#define FX_MODE_SINELON_DUAL            93  // candidate for removal (use sinelon)
-//#define FX_MODE_SINELON_RAINBOW         94  // candidate for removal (use sinelon)
+//#define FX_MODE_SINELON_DUAL            93  // removed in 0.16, use Sinelon with check 2
+//#define FX_MODE_SINELON_RAINBOW         94  // removed in 0.16, use Sinelon with check 1
 #define FX_MODE_POPCORN                 95
 #define FX_MODE_DRIP                    96
 #define FX_MODE_PLASMA                  97
 #define FX_MODE_PERCENT                 98
-//#define FX_MODE_RIPPLE_RAINBOW          99  // candidate for removal (use ripple)
+//#define FX_MODE_RIPPLE_RAINBOW          99  // removed in 0.16, use Sinelon with check 1
 #define FX_MODE_HEARTBEAT              100
 #define FX_MODE_PACIFICA               101
-//#define FX_MODE_CANDLE_MULTI           102  // candidate for removal (use candle with multi select)
-//#define FX_MODE_SOLID_GLITTER          103  // candidate for removal (use glitter)
+//#define FX_MODE_CANDLE_MULTI           102  // removed in 0.16, use Candle with check 3
+//#define FX_MODE_SOLID_GLITTER          103  // removed in 0.16, use Glitter
 #define FX_MODE_SUNRISE                104
 #define FX_MODE_PHASED                 105
 #define FX_MODE_TWINKLEUP              106
@@ -244,24 +244,24 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_PHASEDNOISE            109
 #define FX_MODE_FLOW                   110
 #define FX_MODE_CHUNCHUN               111
-#define FX_MODE_DANCING_SHADOWS        112
+#define FX_MODE_DANCING_SHADOWS        112  // alternative: PS Dancing Shadows
 #define FX_MODE_WASHING_MACHINE        113
 #define FX_MODE_2DPLASMAROTOZOOM       114 // was Candy Cane prior to 0.14 (use Chase 2)
 #define FX_MODE_BLENDS                 115
 #define FX_MODE_TV_SIMULATOR           116
-//#define FX_MODE_DYNAMIC_SMOOTH         117 // candidate for removal (check3 in dynamic)
+//#define FX_MODE_DYNAMIC_SMOOTH         117 // removed in 0.16, use Danamic with check3
 
 // new 0.14 2D effects
-#define FX_MODE_2DSPACESHIPS           118 //gap fill
-#define FX_MODE_2DCRAZYBEES            119 //gap fill
-#define FX_MODE_2DGHOSTRIDER           120 //gap fill
-#define FX_MODE_2DBLOBS                121 //gap fill
-#define FX_MODE_2DSCROLLTEXT           122 //gap fill
-#define FX_MODE_2DDRIFTROSE            123 //gap fill
-#define FX_MODE_2DDISTORTIONWAVES      124 //gap fill
-#define FX_MODE_2DSOAP                 125 //gap fill
-#define FX_MODE_2DOCTOPUS              126 //gap fill
-#define FX_MODE_2DWAVINGCELL           127 //gap fill
+#define FX_MODE_2DSPACESHIPS           118
+#define FX_MODE_2DCRAZYBEES            119
+#define FX_MODE_2DGHOSTRIDER           120 // alternative: PS Ghost Rider
+#define FX_MODE_2DBLOBS                121 // alternative: PS Blobs
+#define FX_MODE_2DSCROLLTEXT           122
+#define FX_MODE_2DDRIFTROSE            123
+#define FX_MODE_2DDISTORTIONWAVES      124
+#define FX_MODE_2DSOAP                 125
+#define FX_MODE_2DOCTOPUS              126
+#define FX_MODE_2DWAVINGCELL           127
 
 // WLED-SR effects (SR compatible IDs !!!)
 #define FX_MODE_PIXELS                 128

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -143,10 +143,10 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_RAINBOW                  8
 #define FX_MODE_RAINBOW_CYCLE            9
 #define FX_MODE_SCAN                    10
-#define FX_MODE_DUAL_SCAN               11
+//#define FX_MODE_DUAL_SCAN               11  // candidate for removal (use Scan)
 #define FX_MODE_FADE                    12
 #define FX_MODE_THEATER_CHASE           13
-#define FX_MODE_THEATER_CHASE_RAINBOW   14
+//#define FX_MODE_THEATER_CHASE_RAINBOW   14  // candidate for removal (use Theater)
 #define FX_MODE_RUNNING_LIGHTS          15
 #define FX_MODE_SAW                     16
 #define FX_MODE_TWINKLE                 17
@@ -169,7 +169,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_COLORFUL                34
 #define FX_MODE_TRAFFIC_LIGHT           35
 #define FX_MODE_COLOR_SWEEP_RANDOM      36
-#define FX_MODE_RUNNING_COLOR           37
+//#define FX_MODE_RUNNING_COLOR           37  // candidate for removal (use Theater)
 #define FX_MODE_AURORA                  38
 #define FX_MODE_RUNNING_RANDOM          39
 #define FX_MODE_LARSON_SCANNER          40
@@ -184,7 +184,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_FAIRY                   49  //was Police All prior to 0.13.0-b6 (use "Two Dots" with Red/Blue and full intensity)
 #define FX_MODE_TWO_DOTS                50
 #define FX_MODE_FAIRYTWINKLE            51  //was Two Areas prior to 0.13.0-b6 (use "Two Dots" with full intensity)
-#define FX_MODE_RUNNING_DUAL            52
+//#define FX_MODE_RUNNING_DUAL            52  // candidate for removal (use Running)
 #define FX_MODE_IMAGE                   53
 #define FX_MODE_TRICOLOR_CHASE          54
 #define FX_MODE_TRICOLOR_WIPE           55
@@ -234,7 +234,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 //#define FX_MODE_RIPPLE_RAINBOW          99  // candidate for removal (use ripple)
 #define FX_MODE_HEARTBEAT              100
 #define FX_MODE_PACIFICA               101
-#define FX_MODE_CANDLE_MULTI           102
+//#define FX_MODE_CANDLE_MULTI           102  // candidate for removal (use candle with multi select)
 //#define FX_MODE_SOLID_GLITTER          103  // candidate for removal (use glitter)
 #define FX_MODE_SUNRISE                104
 #define FX_MODE_PHASED                 105


### PR DESCRIPTION
This PR removes some of the classic FX "aliases" and moves them into the main FX to be used with checkmarks. 

cherry picked from @blazoncek's branch, updated, cleaned and tested.

Removed effects:
- Dynamic Smooth -> use Danamic with check3
- Candle Multi -> use Candle with check 3
- Solid Glitter -> use Glitter (alternative: PS Sparkler)
- Ripple Rainbow -> use Ripple with check 1
- Sinelon Dual -> use Sinelon with check 2
- Sinelon Rainbow -> use Sinelon with check 1
- Meteor Smooth -> use Meteor
- Scanner Dual -> use Scanner with check 3
- Running Dual -> use Running with with check 2
- Chase 2 ->  use Theater without check 3
- Dissolve Rnd -> use Dissolve with with check 1
- Saw -> use Running with with check 3
- Theater Rainbow ->  use Theater with check 
- Scan Dual -> use Scan with check 3