### PR TITLE
Make Segment class non-copyable and move-only

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -33,9 +33,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
 
   //DEBUG_PRINTLN(F("-- JSON deserialize segment."));
   Segment& seg = strip.getSegment(id);
-  //DEBUG_PRINTF_P(PSTR("--  Original segment: %p (%p)\n"), &seg, seg.data);
-  const Segment prev = seg; //make a backup so we can tell if something changed (calling copy constructor)
-  //DEBUG_PRINTF_P(PSTR("--  Duplicate segment: %p (%p)\n"), &prev, prev.data);
+  const SegmentSettings prev(seg); //make a backup so we can tell if something changed
 
   int start = elem["start"] | seg.start;
   if (stop < 0) {

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -25,12 +25,11 @@ void setValuesFromSegment(uint8_t s)
 
 
 // applies global legacy values (col, colSec, effectCurrent...)
-// problem: if the first selected segment already has the value to be set, other selected segments are not updated
 void applyValuesToSelectedSegs()
 {
-  // copy of first selected segment to tell if value was updated
-  unsigned firstSel = strip.getFirstSelectedSegId();
-  Segment selsegPrev = strip.getSegment(firstSel);
+  // compare against first selected segment to tell if value was updated
+  const unsigned firstSel = strip.getFirstSelectedSegId();
+  const Segment& selsegPrev = strip.getSegment(firstSel);
   for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
     Segment& seg = strip.getSegment(i);
     if (i != firstSel && (!seg.isActive() || !seg.isSelected())) continue;


### PR DESCRIPTION
This is really pure coincidence... Apparently @TripleWhy and me have been working on the same topic at the same time:
Eliminating copies of the Segment class. See the first PR here: https://github.com/wled/WLED/pull/4578

The reasons for this alternative PR - after hesitating for a long time - are the following:
- This PR prohibits copying of the Segment and WS2812FX class entirely.
- It is less intrusive, preserving most of the existing code.
- It does _not_ treat a segment object as raw memory.

The last point of this list is the most important one IMHO. Using `memcpy()`, `reinterpret_cast()`, and alike on objects seems very convenient in the beginning. But they are also very prone to becoming a really bad pitfall in the future! And the performance gain - if any - is very disputable.
That is also why many C++ coding standards from the industry (MISRA, AUTOSAR, SEI-CERT ...) do not allow using these; see here for example:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-memset
https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions

As said, I was hesitating for a long time, and studied the PR and its discussion intensively. Just wait for the other PR to become available? Or incorporate its suggestions into this C++ compliant PR and give credit?

Well... here's the result. I really hope no one is offended by this alternative!