### PR TITLE
Add warning about unconfigurable outputs

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -789,9 +789,11 @@ Swap: <select id="xw${s}" name="XW${s}">
 			</div>
 		</div>
 		<h3>Hardware setup</h3>
-		<div id="mLC">LED outputs:<br>
-		<hr class="sml">
-		<i>Only last output can be changed. Remove to edit others.<br></i></div>
+		<div id="mLC">
+			LED outputs:<br>
+			<hr class="sml">
+			<i>Only last output can be changed. Remove to edit others.</i><br>
+		</div>
 		<button type="button" id="+" onclick="addLEDs(1,false)">+</button>
 		<button type="button" id="-" onclick="addLEDs(-1,false)">-</button><br>
 		LED memory usage: <span id="m0">0</span> / <span id="m1">?</span> B<br>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -789,8 +789,9 @@ Swap: <select id="xw${s}" name="XW${s}">
 			</div>
 		</div>
 		<h3>Hardware setup</h3>
-		<div id="mLC">LED outputs:</div>
+		<div id="mLC">LED outputs:<br>
 		<hr class="sml">
+		<i>Only last output can be changed. Remove to edit others.</i><br></div>
 		<button type="button" id="+" onclick="addLEDs(1,false)">+</button>
 		<button type="button" id="-" onclick="addLEDs(-1,false)">-</button><br>
 		LED memory usage: <span id="m0">0</span> / <span id="m1">?</span> B<br>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -791,7 +791,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 		<h3>Hardware setup</h3>
 		<div id="mLC">LED outputs:<br>
 		<hr class="sml">
-		<i>Only last output can be changed. Remove to edit others.</i><br></div>
+		<i>Only last output can be changed. Remove to edit others.<br></i></div>
 		<button type="button" id="+" onclick="addLEDs(1,false)">+</button>
 		<button type="button" id="-" onclick="addLEDs(-1,false)">-</button><br>
 		LED memory usage: <span id="m0">0</span> / <span id="m1">?</span> B<br>


### PR DESCRIPTION
Since 0.15 it is now only possible to configure the last output type. This can be confusing for users of pre-assembled boards that ship configured with multiple outputs, so a warning has been added to warn about this behavior.
It's been placed before the first output because some boards are pre-configured with a lot of outputs and thus it would be unlikely for the user to notice the warning since they'd have to scroll all the way to the bottom.
I decided to add a line before the warning because I found it weird to have the title for the section with a colon and then the warning before the outputs without it. It could be added before the title but all other suggestions are below the relevant section.

![chrome_9iFrZoipti](https://github.com/user-attachments/assets/baa55f61-4f8e-4bee-b0ea-f2a1eb0c169d)
