### PR TITLE
Fix wipe effect smoothness

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -183,8 +183,7 @@ uint16_t color_wipe(bool rev, bool useRandomColors) {
   }
 
   unsigned ledIndex = (prog * SEGLEN) >> 15;
-  unsigned rem = 0;
-  rem = (prog * SEGLEN) * 2; //mod 0xFFFF
+  uint16_t rem = (prog * SEGLEN) * 2; //mod 0xFFFF by truncating
   rem /= (SEGMENT.intensity +1);
   if (rem > 255) rem = 255;
 


### PR DESCRIPTION
With update to 15.x many vars got changed to unsigned. Wipe relies on truncation (of an uint16_t) for modulo operation, and was therefore broken.

Using directly an uint16_t like my proposal *should* be overall faster than using an unsigned and then doing a modulo. (Not an expert)