### PR TITLE
Get TTGO-T-Display usermod to build

### DIFF
--- a/usermods/TTGO-T-Display/README.md
+++ b/usermods/TTGO-T-Display/README.md
@@ -49,27 +49,5 @@ Once the platformio_override.ini file has been copied as described above, the pl
 ### Change to the WLED_T-Display environment
 This should appear as an option in the bottom toolbar.
 
-### TFT_eSPI Library Adjustments (board selection)
-You need to modify a file in the `TFT_eSPI` library to select the correct board.  If you followed the directions to modify and save the `platformio.ini` file above, the `User_Setup_Select.h` file can be found in the `/.pio/libdeps/WLED_T-Display/TFT_eSPI` folder.
-
-Modify the  `User_Setup_Select.h` file as follows:
-* Comment out the following line (which is the 'default' setup file):
-```ini
-//#include <User_Setup.h>           // Default setup is root library folder
-```
-* Uncomment the following line (which points to the setup file for the TTGO T-Display):
-```ini
-#include <User_Setups/Setup25_TTGO_T_Display.h>    // Setup file for ESP32 and TTGO T-Display ST7789V SPI bus TFT
-```
-
-Build the file.  If you see a failure like this:
-```ini
-xtensa-esp32-elf-g++: error: wled00\wled00.ino.cpp: No such file or directory
-xtensa-esp32-elf-g++: fatal error: no input files
-```
-try building again. Sometimes this happens on the first build attempt and subsequent attempts build correctly.
-
 Once the compilation is done and loaded onto the TTGO T-Display module, the display should show "Loading...", and then it will show the IP of the WLED access point.
 
-## Arduino IDE
-- UNTESTED

--- a/usermods/TTGO-T-Display/library.json
+++ b/usermods/TTGO-T-Display/library.json
@@ -1,0 +1,9 @@
+{
+  "name:": "TTGO-T-Display",
+  "dependencies": {
+    "TFT_eSPI" : "https://github.com/Bodmer/TFT_eSPI/archive/refs/tags/2.1.4.zip"
+  },
+  "build": {
+    "extraScript": "set_build_flags.py"
+  }
+}

--- a/usermods/TTGO-T-Display/platformio_override.ini
+++ b/usermods/TTGO-T-Display/platformio_override.ini
@@ -19,7 +19,6 @@ platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"WLED_T-Display\" 
-    ${esp32.AR_build_flags}
 ;  -D IRPIN=4
 ;  -D RLYPIN=12
 ;  -D RLYMDE=1
@@ -35,22 +34,6 @@ build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"
 ;  -D RLYODRAIN=0
 ;  -D LED_BUILTIN=2 # GPIO of built-in LED
 lib_deps = ${esp32.lib_deps}
-  #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
-    ;TFT_eSPI @ 2.5.33
-    https://github.com/Bodmer/TFT_eSPI/archive/refs/tags/2.1.4.zip
-    ;https://github.com/Bodmer/TFT_eSPI/archive/refs/tags/2.1.9.zip
-    kosme/arduinoFFT @ 2.0.1
+custom_usermods = audioreactive TTGO-T-Display
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
-
-; # additional build flags for audioreactive
-; Use Audioreactive usermod and configure I2S microphone
-;   ${esp32.AR_build_flags} ;; default flags required to properly configure ArduinoFFT
-;   ;; don't forget to add ArduinoFFT to your libs_deps: ${esp32.AR_lib_deps}
-;   -D AUDIOPIN=-1
-;   -D DMTYPE=1     # 0-analog/disabled, 1-I2S generic, 2-ES7243, 3-SPH0645, 4-I2S+mclk, 5-I2S PDM
-;   -D I2S_SDPIN=36
-;   -D I2S_WSPIN=23
-;   -D I2S_CKPIN=19
-;  ${esp32.AR_lib_deps} ;; needed for USERMOD_AUDIOREACTIVE
-; AR_lib_deps = kosme/arduinoFFT @ 2.0.1

--- a/usermods/TTGO-T-Display/set_build_flags.py
+++ b/usermods/TTGO-T-Display/set_build_flags.py
@@ -1,0 +1,21 @@
+# Select target board
+# Ref: https://github.com/Bodmer/TFT_eSPI/wiki/Installing-on-PlatformIO#4-configure-library
+# These flags are passed to this library and the TFT_eSPI library only
+
+Import("env")
+
+def add_display_setup(tgt_env):
+    tgt_env.Append(CPPDEFINES=[("USER_SETUP_LOADED", "1")])
+    tgt_env.Append(CCFLAGS="-include $PROJECT_LIBDEPS_DIR/$PIOENV/TFT_eSPI/User_Setups/Setup25_TTGO_T_Display.h")
+
+add_display_setup(env)
+for lb in env.GetLibBuilders():
+    if lb.name == "TFT_eSPI":
+        add_display_setup(lb.env)
+        break
+
+# Add pin definitions to whole project environment if they haven't otherwise been specified
+global_env = DefaultEnvironment()
+global_defines = global_env.get("CPPDEFINES", [])
+if "BTNPIN" not in [v[0] for v in global_defines if isinstance(v, tuple)]:
+    global_env.Append(CPPDEFINES=[("BTNPIN", "35")])

--- a/usermods/TTGO-T-Display/usermod.cpp
+++ b/usermods/TTGO-T-Display/usermod.cpp
@@ -75,20 +75,20 @@ void userSetup() {
 void userConnected() {}
 
 // needRedraw marks if redraw is required to prevent often redrawing.
-bool needRedraw = true;
+static bool needRedraw = true;
 
 // Next variables hold the previous known values to determine if redraw is
 // required.
-String knownSsid = "";
-IPAddress knownIp;
-uint8_t knownBrightness = 0;
-uint8_t knownMode = 0;
-uint8_t knownPalette = 0;
-uint8_t tftcharwidth = 19;  // Number of chars that fit on screen with text size set to 2
+static String knownSsid = "";
+static IPAddress knownIp;
+static uint8_t knownBrightness = 0;
+static uint8_t knownMode = 0;
+static uint8_t knownPalette = 0;
+static uint8_t tftcharwidth = 19;  // Number of chars that fit on screen with text size set to 2
 
-long lastUpdate_mod = 0;
-long lastRedraw = 0;
-bool displayTurnedOff = false;
+static long lastUpdate_mod = 0;
+static long lastRedraw = 0;
+static bool displayTurnedOff = false;
 // How often we are redrawing screen
 #define USER_LOOP_REFRESH_RATE_MS 5000
 

--- a/wled00/usermod.cpp
+++ b/wled00/usermod.cpp
@@ -11,19 +11,19 @@
 //Use userVar0 and userVar1 (API calls &U0=,&U1=, uint16_t)
 
 //gets called once at boot. Do all initialization that doesn't depend on network here
-void userSetup()
+__attribute__((weak)) void userSetup()
 {
 
 }
 
 //gets called every time WiFi is (re-)connected. Initialize own network interfaces here
-void userConnected()
+__attribute__((weak)) void userConnected()
 {
 
 }
 
 //loop. You can use "if (WLED_CONNECTED)" to check for successful connection
-void userLoop()
+__attribute__((weak)) void userLoop() 
 {
 
 }


### PR DESCRIPTION
Adopt spiff72's upstream changes, and update the TTGO-T-Display usermod to the new library framework.  This allows it to be included in `custom_usermods` like any other usermod.  All other build requirements are handled by a library script, so the TFT_eSPI library does not need to be hand modified.

Fixes #4375.

NOTE: I do not actually have this hardware, so this is untested beyond "it builds"; I've double checked that the correct build flags are handed to each source, but that's about as far as I can go.   Can someone with one of these boards please give it a try?