### PR TITLE
Fix unused variabe compiler warning

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -751,7 +751,7 @@ void WLED::handleConnection()
   static bool scanDone = true;
   static byte stacO = 0;
   const unsigned long now = millis();
-  const unsigned long nowS = now/1000;
+  [[maybe_unused]] const unsigned long nowS = now/1000;
   const bool wifiConfigured = WLED_WIFI_CONFIGURED;
 
   // ignore connection handling if WiFi is configured and scan still running


### PR DESCRIPTION
Variable is only used in debug logs, so is unused when compiled without debug.