### PR TITLE
Inject a dependency on the usermod list

### DIFF
--- a/pio-scripts/add_usermod_dep.py
+++ b/pio-scripts/add_usermod_dep.py
@@ -1,0 +1,25 @@
+# Attempt to fix incorrect SCons cache lookups
+# The build system doesn't seem to always pick up cases where the dependency list itself has
+# changed, and can incorrectly return a cached build result with the wrong set of usermods
+# linked in.
+# We put the usermod list in a file which can be listed as dep for the final link,
+# ensuring that it will always link correctly based on the hashes.
+
+Import('env')
+from pathlib import Path
+
+# Write out the usermod list to a text file
+lib_path = Path(env.subst("$PROJECT_LIBDEPS_DIR")) / env.subst("$PIOENV")
+usermods = env.GetProjectOption("custom_usermods","")
+usermod_file = Path(lib_path) / "usermod_list.txt"
+
+with usermod_file.open("a+", encoding="utf-8") as um_file:
+  um_file.seek(0)
+  old_ums = um_file.readline()
+  if old_ums != usermods:
+    um_file.truncate(0)
+    um_file.seek(0)
+    um_file.write(usermods)
+
+# Add a dependency on this file
+env.Depends(env.subst("$PROGPATH"), str(usermod_file))

--- a/platformio.ini
+++ b/platformio.ini
@@ -115,6 +115,7 @@ extra_scripts =
   post:pio-scripts/strip-floats.py
   pre:pio-scripts/user_config_copy.py
   pre:pio-scripts/load_usermods.py
+  post:pio-scripts/add_usermod_dep.py
   pre:pio-scripts/build_ui.py
   ; post:pio-scripts/obj-dump.py  ;; convenience script to create a disassembly dump of the firmware (hardcore debugging)
 


### PR DESCRIPTION
Write the current usermod list to a file, and add it as a dependency to the linked output file.  This should hopefully overcome potential poisoning of SCons' build cache with incorrect matches.

Meant to fix #4597, though I haven't been able to reproduce it locally.  I tested the dependency injection by disabling the overwite code and manually editing the usermods list file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated post-processing step in the build process that improves how custom modifications are tracked and integrated.
  - Ensured that dependency updates are applied reliably, enhancing overall build consistency and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->