### PR TITLE
Adds hostname (serverDescription) to log in net debug

### DIFF
--- a/wled00/net_debug.cpp
+++ b/wled00/net_debug.cpp
@@ -2,9 +2,7 @@
 
 #ifdef WLED_DEBUG_HOST
 
-size_t NetworkDebugPrinter::write(uint8_t c) {
-  if (!WLED_CONNECTED || !netDebugEnabled) return 0;
-
+void NetworkDebugPrinter::resolveHostName() {
   if (!debugPrintHostIP && !debugPrintHostIP.fromString(netDebugPrintHost)) {
     #ifdef ESP8266
       WiFi.hostByName(netDebugPrintHost, debugPrintHostIP, 750);
@@ -16,31 +14,53 @@ size_t NetworkDebugPrinter::write(uint8_t c) {
       #endif
     #endif
   }
+}
 
+void NetworkDebugPrinter::flushBuffer() {
+  if (buffer.length() == 0) return;
+  
+  resolveHostName();
+  
   debugUdp.beginPacket(debugPrintHostIP, netDebugPrintPort);
-  debugUdp.write(c);
+  debugUdp.printf("%s %s", serverDescription, buffer.c_str());
   debugUdp.endPacket();
+  buffer = "";
+}
+
+size_t NetworkDebugPrinter::write(uint8_t c) {
+  if (!WLED_CONNECTED || !netDebugEnabled) return 0;
+  
+  buffer += (char)c;
+  
+  // Flush on newline or if buffer gets too large
+  if (c == '\n' || buffer.length() >= MAX_BUFFER_SIZE) {
+    flushBuffer();
+  }
+  
   return 1;
 }
 
 size_t NetworkDebugPrinter::write(const uint8_t *buf, size_t size) {
   if (!WLED_CONNECTED || buf == nullptr || !netDebugEnabled) return 0;
-
-  if (!debugPrintHostIP && !debugPrintHostIP.fromString(netDebugPrintHost)) {
-    #ifdef ESP8266
-      WiFi.hostByName(netDebugPrintHost, debugPrintHostIP, 750);
-    #else
-      #ifdef WLED_USE_ETHERNET
-        ETH.hostByName(netDebugPrintHost, debugPrintHostIP);
-      #else
-        WiFi.hostByName(netDebugPrintHost, debugPrintHostIP);
-      #endif
-    #endif
+  
+  // Check if we can find a newline in the buffer
+  bool hasNewline = false;
+  size_t lastNewlinePos = 0;
+  
+  for (size_t i = 0; i < size; i++) {
+    buffer += (char)buf[i];
+    if (buf[i] == '\n') {
+      hasNewline = true;
+      lastNewlinePos = i;
+      flushBuffer();
+    }
   }
-
-  debugUdp.beginPacket(debugPrintHostIP, netDebugPrintPort);
-  size = debugUdp.write(buf, size);
-  debugUdp.endPacket();
+  
+  // If buffer is large but no newline was found, flush anyway
+  if (!hasNewline && buffer.length() >= MAX_BUFFER_SIZE) {
+    flushBuffer();
+  }
+  
   return size;
 }
 

--- a/wled00/net_debug.cpp
+++ b/wled00/net_debug.cpp
@@ -43,21 +43,15 @@ size_t NetworkDebugPrinter::write(uint8_t c) {
 size_t NetworkDebugPrinter::write(const uint8_t *buf, size_t size) {
   if (!WLED_CONNECTED || buf == nullptr || !netDebugEnabled) return 0;
   
-  // Check if we can find a newline in the buffer
-  bool hasNewline = false;
-  size_t lastNewlinePos = 0;
-  
   for (size_t i = 0; i < size; i++) {
     buffer += (char)buf[i];
     if (buf[i] == '\n') {
-      hasNewline = true;
-      lastNewlinePos = i;
       flushBuffer();
     }
   }
   
   // If buffer is large but no newline was found, flush anyway
-  if (!hasNewline && buffer.length() >= MAX_BUFFER_SIZE) {
+  if (buffer.length() >= MAX_BUFFER_SIZE) {
     flushBuffer();
   }
   

--- a/wled00/net_debug.h
+++ b/wled00/net_debug.h
@@ -6,14 +6,16 @@
 
 class NetworkDebugPrinter : public Print {
   private:
-    WiFiUDP debugUdp; // needs to be here otherwise UDP messages get truncated upon destruction
+    WiFiUDP debugUdp;
     IPAddress debugPrintHostIP;
+    String buffer;
+    const size_t MAX_BUFFER_SIZE = 1024; // Safety limit
+    void resolveHostName();
+    void flushBuffer();
   public:
     virtual size_t write(uint8_t c);
     virtual size_t write(const uint8_t *buf, size_t s);
 };
-
-// use it on your linux/macOS with: nc -p 7868 -u -l -s <network ip>
 extern NetworkDebugPrinter NetDebug;
 
 #endif


### PR DESCRIPTION
Fix for https://github.com/wled/WLED/issues/4647

Adds the hostname (serverDescription) to the send output. 

Output before:

Apr 16 20:46:20 Segment geometry: 0,30 -> 0,1

With this fix:

Apr 19 16:06:20 EleksTube Wifi state: 3

So now the syslog server creates only one file syslog-EleksTube.log instead of multiple (see picture in https://github.com/wled/WLED/issues/4647)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved network debug output by buffering messages and sending them in batches, resulting in more organized and grouped UDP debug logs.
  - Enhanced hostname resolution efficiency for debug output.
  - Reduced network traffic by minimizing the number of UDP packets sent during debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->