### PR TITLE
Only disable Arduino OTA when using -D WLED_DISABLE_OTA

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -611,7 +611,9 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   if (pwdCorrect) { //only accept these values from cfg.json if ota is unlocked (else from wsec.json)
     CJSON(otaLock, ota[F("lock")]);
     CJSON(wifiLock, ota[F("lock-wifi")]);
+    #ifndef WLED_DISABLE_OTA
     CJSON(aOtaEnabled, ota[F("aota")]);
+    #endif
     getStringFromJson(otaPass, pwd, 33); //normally not present due to security
   }
 
@@ -1103,7 +1105,9 @@ void serializeConfig(JsonObject root) {
   ota[F("lock")] = otaLock;
   ota[F("lock-wifi")] = wifiLock;
   ota[F("pskl")] = strlen(otaPass);
+  #ifndef WLED_DISABLE_OTA
   ota[F("aota")] = aOtaEnabled;
+  #endif
 
   #ifdef WLED_ENABLE_DMX
   JsonObject dmx = root.createNestedObject("dmx");
@@ -1174,7 +1178,9 @@ bool deserializeConfigSec() {
   getStringFromJson(otaPass, ota[F("pwd")], 33);
   CJSON(otaLock, ota[F("lock")]);
   CJSON(wifiLock, ota[F("lock-wifi")]);
+  #ifndef WLED_DISABLE_OTA
   CJSON(aOtaEnabled, ota[F("aota")]);
+  #endif
 
   releaseJSONBufferLock();
   return true;
@@ -1214,7 +1220,9 @@ void serializeConfigSec() {
   ota[F("pwd")] = otaPass;
   ota[F("lock")] = otaLock;
   ota[F("lock-wifi")] = wifiLock;
+  #ifndef WLED_DISABLE_OTA
   ota[F("aota")] = aOtaEnabled;
+  #endif
 
   File f = WLED_FS.open(FPSTR(s_wsec_json), "w");
   if (f) serializeJson(root, f);

--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -56,7 +56,7 @@
 		<hr>
 		<h3>Software Update</h3>
 		<button type="button" onclick="U()">Manual OTA Update</button><br>
-		Enable ArduinoOTA: <input type="checkbox" name="AO">
+		<div id="aOTA">Enable ArduinoOTA: <input type="checkbox" name="AO"></div>
 		<hr id="backup">
 		<h3>Backup & Restore</h3>
 		<div class="warn">&#9888; Restoring presets/configuration will OVERWRITE your current presets/configuration.<br>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -593,7 +593,9 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     {
       otaLock = request->hasArg(F("NO"));
       wifiLock = request->hasArg(F("OW"));
+      #ifndef WLED_DISABLE_OTA
       aOtaEnabled = request->hasArg(F("AO"));
+      #endif
       //createEditHandler(correctPIN && !otaLock);
     }
   }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -584,7 +584,11 @@ WLED_GLOBAL bool otaLock        _INIT(true);     // prevents OTA firmware update
 WLED_GLOBAL bool otaLock        _INIT(false);     // prevents OTA firmware updates without password. ALWAYS enable if system exposed to any public networks
 #endif
 WLED_GLOBAL bool wifiLock       _INIT(false);     // prevents access to WiFi settings when OTA lock is enabled
+#ifndef WLED_DISABLE_OTA
 WLED_GLOBAL bool aOtaEnabled    _INIT(true);      // ArduinoOTA allows easy updates directly from the IDE. Careful, it does not auto-disable when OTA lock is on
+#else
+WLED_GLOBAL bool aOtaEnabled    _INIT(false);     // ArduinoOTA allows easy updates directly from the IDE. Careful, it does not auto-disable when OTA lock is on
+#endif
 WLED_GLOBAL char settingsPIN[5] _INIT(WLED_PIN);  // PIN for settings pages
 WLED_GLOBAL bool correctPIN     _INIT(!strlen(settingsPIN));
 WLED_GLOBAL unsigned long lastEditTime _INIT(0);

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -365,7 +365,6 @@ void initServer()
   createEditHandler(correctPIN);
 
   static const char _update[] PROGMEM = "/update";
-#ifndef WLED_DISABLE_OTA
   //init ota page
   server.on(_update, HTTP_GET, [](AsyncWebServerRequest *request){
     if (otaLock) {
@@ -419,12 +418,6 @@ void initServer()
       }
     }
   });
-#else
-  server.on(_update, HTTP_GET, [](AsyncWebServerRequest *request){
-    serveMessage(request, 501, FPSTR(s_notimplemented), F("OTA updating is disabled in this build."), 254);
-  });
-#endif
-
 
 #ifdef WLED_ENABLE_DMX
   server.on(F("/dmxmap"), HTTP_GET, [](AsyncWebServerRequest *request){

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -595,6 +595,10 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     snprintf_P(tmp_buf,sizeof(tmp_buf),PSTR("WLED %s (build %d)"),versionString,VERSION);
     printSetClassElementHTML(settingsScript,PSTR("sip"),0,tmp_buf);
     settingsScript.printf_P(PSTR("sd=\"%s\";"), serverDescription);
+    #ifdef WLED_DISABLE_OTA
+    //hide settings if not compiled
+    settingsScript.print(F("toggle('aOTA');"));  // hide ArduinoOTA checkbox
+    #endif
   }
 
   #ifdef WLED_ENABLE_DMX // include only if DMX is enabled


### PR DESCRIPTION
- since Update object is accessible even with ArduinoOTA disabled it should possible to use HTTP OTA regardless
- this (using WLED_DISABLE_OTA) saves about 12kB while still allowing HTTP OTA updates
- HTTP OTA updates can be blocked using PIN or OTA lock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - OTA update functionality is now always available, removing the previous option to disable it at build time. The fallback message for disabled OTA updates has been removed.
  - The "Enable ArduinoOTA" option in the settings UI is now hidden when OTA updates are disabled at compile time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->