### PR TITLE
add support for up to 10 ESPNow remotes

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -39,7 +39,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 #ifndef WLED_DISABLE_ESPNOW
   CJSON(enableESPNow, nw[F("espnow")]);
   linked_remotes.clear();
-  JsonArray lrem = nw[F("lrem")]; // array of MAC addresses
+  JsonArray lrem = nw[F("linked_remote")]; // array of MAC addresses
   if (!lrem.isNull()) {
     for (size_t i = 0; i < lrem.size(); i++) {
       std::array<char, 13> entry{};
@@ -739,7 +739,7 @@ void serializeConfig(JsonObject root) {
   JsonObject nw = root.createNestedObject("nw");
 #ifndef WLED_DISABLE_ESPNOW
   nw[F("espnow")] = enableESPNow;
-  JsonArray lrem = nw.createNestedArray(F("lrem"));
+  JsonArray lrem = nw.createNestedArray(F("linked_remote"));
   for (size_t i = 0; i < linked_remotes.size(); i++) {
     lrem.add(linked_remotes[i].data());
   }

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -39,20 +39,22 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 #ifndef WLED_DISABLE_ESPNOW
   CJSON(enableESPNow, nw[F("espnow")]);
   linked_remotes.clear();
-  JsonArray lrem = nw[F("linked_remote")]; // array of MAC addresses
+  JsonVariant lrem = nw[F("linked_remote")];
   if (!lrem.isNull()) {
-    for (size_t i = 0; i < lrem.size(); i++) {
-      std::array<char, 13> entry{};
-      getStringFromJson(entry.data(), lrem[i], 13);
-      entry[12] = '\0';
-      linked_remotes.push_back(entry); // TODO: need to check for invalid MAC?
+     if (lrem.is<JsonArray>()) {
+      for (size_t i = 0; i < lrem.size(); i++) {
+        std::array<char, 13> entry{};
+        getStringFromJson(entry.data(), lrem[i], 13);
+        entry[12] = '\0';
+        linked_remotes.emplace_back(entry);
+      }
     }
-  }
-  else { // legacy support for single MAC address in config
-    std::array<char, 13> entry{};
-    getStringFromJson(entry.data(), nw[F("linked_remote")], 13);
-    entry[12] = '\0';
-    linked_remotes.push_back(entry);
+    else { // legacy support for single MAC address in config
+      std::array<char, 13> entry{};
+      getStringFromJson(entry.data(), lrem, 13);
+      entry[12] = '\0';
+      linked_remotes.emplace_back(entry);
+    }
   }
 #endif
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -45,7 +45,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
       std::array<char, 13> entry{};
       getStringFromJson(entry.data(), lrem[i], 13);
       entry[12] = '\0';
-      linked_remotes.push_back(entry); // TODO: is this a good way to check for invalid MAC?
+      linked_remotes.push_back(entry); // TODO: need to check for invalid MAC?
     }
   }
   else { // legacy support for single MAC address in config

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -157,29 +157,17 @@ Static subnet mask:<br>
 		function aR(id, mac) {
 			if (!/^[0-9A-F]{12}$/i.test(mac)) return; // check for valid hex string
 			if (rC >= 10) return;
-			let inputs = gId('rml').getElementsByTagName('input');
-			for (let i = 0; i < inputs.length; i++) {
-				if (inputs[i].value === mac) return;
+			let inputs = d.querySelectorAll("#rml input");
+			for (let i of (inputs || [])) {
+				if (i.value === mac) return;
 			}
-			let list = gId('rml');
-			let row = cE('div');
-			let inp = cE('input');
-			inp.type = 'text';
-			inp.name = id;
-			inp.value = mac;
-			inp.maxLength = 12;
-			inp.minLength = 12;
-			inp.onchange = uR;
-			row.appendChild(inp);
-			let btn = d.createElement('button');
-			btn.type = 'button';
-			//btn.className = 'btn btn-xs';
-			btn.innerText = '-';
-			btn.onclick = function() {
-				rR(row);
-			};
-			row.appendChild(btn);
-			list.appendChild(row);
+			let l = gId('rml'), r = cE('div'), i = cE('input');
+			i.type = 'text'; i.name = id; i.value = mac; i.maxLength = 12; i.minLength = 12; i.onchange = uR;
+			r.appendChild(i);
+			let b = cE('button');
+			b.type = 'button'; b.innerText = '-'; b.onclick = () => rR(r);
+			r.appendChild(b);
+			l.appendChild(r);
 			rC++;
 			uR();
 		}
@@ -191,12 +179,9 @@ Static subnet mask:<br>
 		// update remote list
 		function uR() {
 			let macs = [];
-			let inputs = gId('rml').getElementsByTagName('input');
-			for (let i = 0; i < inputs.length; i++) {
-				if (inputs[i].value && inputs[i].value !== '') {
-					macs.push(inputs[i].value);
-				}
-			}
+			d.querySelectorAll('#rml input').forEach(o => {
+				if (o.value) macs.push(o.value);
+			});
 			gId('rmacs').value = JSON.stringify(macs);
 			return true; // Allow form submission to continue
 		}

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -244,7 +244,7 @@ Static subnet mask:<br>
 		<div id="ESPNOW">
 			Enable ESP-NOW: <input type="checkbox" name="RE" onchange="tE()"><br>
 			<i>Listen for events over ESP-NOW<br>
-			Keep disabled if not using a remote or wireless sync, increases power consumption.<br></i>
+			Keep disabled if not using a remote or ESP-NOW sync, increases power consumption.<br></i>
 			<div id="rlc">
 				Last device seen: <span class="rlid" id="ld">None</span>
 				<button type="button" class="sml" id="+" onclick="aR('RM'+rC,gId('ld').textContent)">+</button><br>

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -136,70 +136,70 @@ Static subnet mask:<br>
 			getLoc();
 			loadJS(getURL('/settings/s.js?p=1'), false);	// If we set async false, file is loaded and executed, then next statement is processed
 			if (loc) d.Sf.action = getURL('/settings/wifi');
-      setTimeout(tE, 500); // wait for DOM to load before calling tE()
+			setTimeout(tE, 500); // wait for DOM to load before calling tE()
 		}
 
-    var rC = 0; // remote count
-    // toggle visibility of ESP-NOW remote list based on checkbox state
-    function tE() {
-      const e = d.querySelector('input[name="RE"]').checked;
-      const l = gId('rlc');  // remote list container
-      // keep the hidden input with MAC addresses, only toggle visibility of the list UI
-      if (l) l.style.display = e ? 'block' : 'none';
-    }
-    // reset remotes: initialize empty list (called from xml.cpp)
-    function rstR() {
-      gId('rml').innerHTML = ''; // clear remote list
-      rC = 0;
-      uR(); // update remote list
-    }
-    // add remote MAC to the list
-    function aR(id, mac) {
-      if (!/^[0-9A-F]{12}$/i.test(mac)) return; // check for valid hex string
-      if (rC >= 10) return;
-      let inputs = gId('rml').getElementsByTagName('input');
-      for (let i = 0; i < inputs.length; i++) {
-        if (inputs[i].value === mac) return;
-      }
-      let list = gId('rml');
-      let row = cE('div');
-      let inp = cE('input');
-      inp.type = 'text';
-      inp.name = id;
-      inp.value = mac;
-      inp.maxLength = 12;
-      inp.minLength = 12;
-      inp.onchange = uR;
-      row.appendChild(inp);
-      let btn = d.createElement('button');
-      btn.type = 'button';
-      btn.className = 'btn btn-xs';
-      btn.innerText = 'Remove';
-      btn.onclick = function() {
-        rR(row);
-      };
-      row.appendChild(btn);
-      list.appendChild(row);
-      rC++;
-      uR();
-    }
-    // remove a remote from the list
-    function rR(e) {
-      e.remove();
-      uR();
-    }
-    // update remote list
-    function uR() {
-      let macs = [];
-      let inputs = gId('rml').getElementsByTagName('input');
-      for (let i = 0; i < inputs.length; i++) {
-        if (inputs[i].value && inputs[i].value !== '') {
-          macs.push(inputs[i].value);
-        }
-      }
-      gId('rmacs').value = JSON.stringify(macs);
-      return true; // Allow form submission to continue
-    }
+		var rC = 0; // remote count
+		// toggle visibility of ESP-NOW remote list based on checkbox state
+		function tE() {
+			const e = d.querySelector('input[name="RE"]').checked;
+			const l = gId('rlc');  // remote list container
+			// keep the hidden input with MAC addresses, only toggle visibility of the list UI
+			if (l) l.style.display = e ? 'block' : 'none';
+		}
+		// reset remotes: initialize empty list (called from xml.cpp)
+		function rstR() {
+			gId('rml').innerHTML = ''; // clear remote list
+			rC = 0;
+			uR(); // update remote list
+		}
+		// add remote MAC to the list
+		function aR(id, mac) {
+			if (!/^[0-9A-F]{12}$/i.test(mac)) return; // check for valid hex string
+			if (rC >= 10) return;
+			let inputs = gId('rml').getElementsByTagName('input');
+			for (let i = 0; i < inputs.length; i++) {
+				if (inputs[i].value === mac) return;
+			}
+			let list = gId('rml');
+			let row = cE('div');
+			let inp = cE('input');
+			inp.type = 'text';
+			inp.name = id;
+			inp.value = mac;
+			inp.maxLength = 12;
+			inp.minLength = 12;
+			inp.onchange = uR;
+			row.appendChild(inp);
+			let btn = d.createElement('button');
+			btn.type = 'button';
+			//btn.className = 'btn btn-xs';
+			btn.innerText = '-';
+			btn.onclick = function() {
+				rR(row);
+			};
+			row.appendChild(btn);
+			list.appendChild(row);
+			rC++;
+			uR();
+		}
+		// remove a remote from the list
+		function rR(e) {
+			e.remove();
+			uR();
+		}
+		// update remote list
+		function uR() {
+			let macs = [];
+			let inputs = gId('rml').getElementsByTagName('input');
+			for (let i = 0; i < inputs.length; i++) {
+				if (inputs[i].value && inputs[i].value !== '') {
+					macs.push(inputs[i].value);
+				}
+			}
+			gId('rmacs').value = JSON.stringify(macs);
+			return true; // Allow form submission to continue
+		}
 	</script>
 	<style>@import url("style.css");</style>
 </head>
@@ -265,17 +265,17 @@ Static subnet mask:<br>
 			<i class="warn">This firmware build does not include ESP-NOW support.<br></i>
 		</div>
 		<div id="ESPNOW">
-      Enable ESP-NOW: <input type="checkbox" name="RE" onchange="tE()"><br>
+			Enable ESP-NOW: <input type="checkbox" name="RE" onchange="tE()"><br>
 			<i>Listen for events over ESP-NOW<br>
 			Keep disabled if not using a remote or wireless sync, increases power consumption.<br></i>
-      <div id="rlc">
-        Last device seen: <span class="rlid" id="ld">None</span>
-        <button type="button" class="btn btn-xs" onclick="aR('RM'+rC,gId('ld').textContent)">Add</button><br>
-        Linked MACs:<br>
-        <div id="rml">
-        </div>
-      </div>
-      <input type="hidden" name="RMA" id="rmacs">
+			<div id="rlc">
+				Last device seen: <span class="rlid" id="ld">None</span>
+				<button type="button" onclick="aR('RM'+rC,gId('ld').textContent)">+</button><br>
+				Linked MACs:<br>
+				<div id="rml">
+				</div>
+			</div>
+			<input type="hidden" name="RMA" id="rmacs">
 		</div>
 
 		<div id="ethd">

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -136,68 +136,75 @@ Static subnet mask:<br>
 			getLoc();
 			loadJS(getURL('/settings/s.js?p=1'), false);	// If we set async false, file is loaded and executed, then next statement is processed
 			if (loc) d.Sf.action = getURL('/settings/wifi');
+      setTimeout(tE, 500); // wait for DOM to load before calling tE()
 		}
 
-    var remoteCount = 0;
-    // Initialize empty list for remotes
-    function resetRemotes() {
-      d.getElementById('rmlist').innerHTML = '';
-      remoteCount = 0;
-      updateRMArray();
+    var rC = 0; // remote count
+    // toggle visibility of ESP-NOW remote list based on checkbox state
+    function tE() {
+      const e = d.querySelector('input[name="RE"]').checked;
+      const l = gId('rlc');  // remote list container
+      // keep the hidden input with MAC addresses, only toggle visibility of the list UI
+      if (l) l.style.display = e ? 'block' : 'none';
     }
-
-    // Add a Remote MAC to the list
-    function addRemote(id, mac) {
-      if (!mac || mac === 'None') return;
-      if (remoteCount >= 10) return;
-      let inputs = d.getElementById('rmlist').getElementsByTagName('input');
+    // reset remotes: initialize empty list (called from xml.cpp)
+    function rstR() {
+      gId('rml').innerHTML = ''; // clear remote list
+      rC = 0;
+      uR(); // update remote list
+    }
+    // add remote MAC to the list
+    function aR(id, mac) {
+      if (!/^[0-9A-F]{12}$/i.test(mac)) return; // check for valid hex string
+      if (rC >= 10) return;
+      let inputs = gId('rml').getElementsByTagName('input');
       for (let i = 0; i < inputs.length; i++) {
         if (inputs[i].value === mac) return;
       }
-      let list = d.getElementById('rmlist');
-      let row = d.createElement('div');
-      let inp = d.createElement('input');
+      let list = gId('rml');
+      let row = cE('div');
+      let inp = cE('input');
       inp.type = 'text';
       inp.name = id;
       inp.value = mac;
       inp.maxLength = 12;
       inp.minLength = 12;
-      inp.onchange = updateRMArray;
+      inp.onchange = uR;
       row.appendChild(inp);
       let btn = d.createElement('button');
       btn.type = 'button';
       btn.className = 'btn btn-xs';
       btn.innerText = 'Remove';
       btn.onclick = function() {
-        removeRemote(row);
+        rR(row);
       };
       row.appendChild(btn);
       list.appendChild(row);
-      remoteCount++;
-      updateRMArray();
+      rC++;
+      uR();
     }
-    // Remove a remote from the list
-    function removeRemote(element) {
-      element.remove();
-      updateRMArray();
+    // remove a remote from the list
+    function rR(e) {
+      e.remove();
+      uR();
     }
-    // Update hidden input with JSON array of MACs
-    function updateRMArray() {
+    // update remote list
+    function uR() {
       let macs = [];
-      let inputs = d.getElementById('rmlist').getElementsByTagName('input');
+      let inputs = gId('rml').getElementsByTagName('input');
       for (let i = 0; i < inputs.length; i++) {
         if (inputs[i].value && inputs[i].value !== '') {
           macs.push(inputs[i].value);
         }
       }
-      d.getElementById('rmacs').value = JSON.stringify(macs);
+      gId('rmacs').value = JSON.stringify(macs);
       return true; // Allow form submission to continue
     }
 	</script>
 	<style>@import url("style.css");</style>
 </head>
 <body onload="S()">
-  <form id="form_s" name="Sf" method="post" onsubmit="return updateRMArray()">
+  <form id="form_s" name="Sf" method="post" onsubmit="return uR()">
 		<div class="toprow">
 		<div class="helpB"><button type="button" onclick="H('features/settings/#wifi-settings')">?</button></div>
 		<button type="button" onclick="B()">Back</button><button type="submit">Save & Connect</button><hr>
@@ -258,13 +265,15 @@ Static subnet mask:<br>
 			<i class="warn">This firmware build does not include ESP-NOW support.<br></i>
 		</div>
 		<div id="ESPNOW">
-			Enable ESP-NOW: <input type="checkbox" name="RE"><br>
+      Enable ESP-NOW: <input type="checkbox" name="RE" onchange="tE()"><br>
 			<i>Listen for events over ESP-NOW<br>
 			Keep disabled if not using a remote or wireless sync, increases power consumption.<br></i>
-      Last device seen: <span class="rlid">None</span>
-      <button type="button" class="btn btn-xs" onclick="addRemote('RM'+remoteCount,this.parentElement.querySelector('.rlid').textContent)">Add</button><br>
-      Linked MACs:<br>
-      <div id="rmlist">
+      <div id="rlc">
+        Last device seen: <span class="rlid" id="ld">None</span>
+        <button type="button" class="btn btn-xs" onclick="aR('RM'+rC,gId('ld').textContent)">Add</button><br>
+        Linked MACs:<br>
+        <div id="rml">
+        </div>
       </div>
       <input type="hidden" name="RMA" id="rmacs">
 		</div>

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -248,7 +248,7 @@ Static subnet mask:<br>
 			<div id="rlc">
 				Last device seen: <span class="rlid" id="ld">None</span>
 				<button type="button" class="sml" id="+" onclick="aR('RM'+rC,gId('ld').textContent)">+</button><br>
-				Linked MACs:<br>
+				Linked MACs (10 max):<br>
 				<div id="rml">
 				</div>
 			</div>

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -137,11 +137,67 @@ Static subnet mask:<br>
 			loadJS(getURL('/settings/s.js?p=1'), false);	// If we set async false, file is loaded and executed, then next statement is processed
 			if (loc) d.Sf.action = getURL('/settings/wifi');
 		}
+
+    var remoteCount = 0;
+    // Initialize empty list for remotes
+    function resetRemotes() {
+      d.getElementById('rmlist').innerHTML = '';
+      remoteCount = 0;
+      updateRMArray();
+    }
+
+    // Add a Remote MAC to the list
+    function addRemote(id, mac) {
+      if (!mac || mac === 'None') return;
+      if (remoteCount >= 10) return;
+      let inputs = d.getElementById('rmlist').getElementsByTagName('input');
+      for (let i = 0; i < inputs.length; i++) {
+        if (inputs[i].value === mac) return;
+      }
+      let list = d.getElementById('rmlist');
+      let row = d.createElement('div');
+      let inp = d.createElement('input');
+      inp.type = 'text';
+      inp.name = id;
+      inp.value = mac;
+      inp.maxLength = 12;
+      inp.minLength = 12;
+      inp.onchange = updateRMArray;
+      row.appendChild(inp);
+      let btn = d.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn btn-xs';
+      btn.innerText = 'Remove';
+      btn.onclick = function() {
+        removeRemote(row);
+      };
+      row.appendChild(btn);
+      list.appendChild(row);
+      remoteCount++;
+      updateRMArray();
+    }
+    // Remove a remote from the list
+    function removeRemote(element) {
+      element.remove();
+      updateRMArray();
+    }
+    // Update hidden input with JSON array of MACs
+    function updateRMArray() {
+      let macs = [];
+      let inputs = d.getElementById('rmlist').getElementsByTagName('input');
+      for (let i = 0; i < inputs.length; i++) {
+        if (inputs[i].value && inputs[i].value !== '') {
+          macs.push(inputs[i].value);
+        }
+      }
+      d.getElementById('rmacs').value = JSON.stringify(macs);
+      return true; // Allow form submission to continue
+    }
 	</script>
 	<style>@import url("style.css");</style>
 </head>
 <body onload="S()">
-	<form id="form_s" name="Sf" method="post">
+  <form id="form_s" name="Sf" method="post" onsubmit="return updateRMArray()">
 		<div class="toprow">
 		<div class="helpB"><button type="button" onclick="H('features/settings/#wifi-settings')">?</button></div>
 		<button type="button" onclick="B()">Back</button><button type="submit">Save & Connect</button><hr>
@@ -205,8 +261,12 @@ Static subnet mask:<br>
 			Enable ESP-NOW: <input type="checkbox" name="RE"><br>
 			<i>Listen for events over ESP-NOW<br>
 			Keep disabled if not using a remote or wireless sync, increases power consumption.<br></i>
-			Paired Remote MAC: <input type="text" name="RMAC" minlength="12" maxlength="12"><br>
-			Last device seen: <span class="rlid" onclick="d.Sf.RMAC.value=this.textContent;" style="cursor:pointer;">None</span> <br>
+      Last device seen: <span class="rlid">None</span>
+      <button type="button" class="btn btn-xs" onclick="addRemote('RM'+remoteCount,this.parentElement.querySelector('.rlid').textContent)">Add</button><br>
+      Linked MACs:<br>
+      <div id="rmlist">
+      </div>
+      <input type="hidden" name="RMA" id="rmacs">
 		</div>
 
 		<div id="ethd">

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -142,54 +142,46 @@ Static subnet mask:<br>
 		var rC = 0; // remote count
 		// toggle visibility of ESP-NOW remote list based on checkbox state
 		function tE() {
-			const e = d.querySelector('input[name="RE"]').checked;
-			const l = gId('rlc');  // remote list container
 			// keep the hidden input with MAC addresses, only toggle visibility of the list UI
-			if (l) l.style.display = e ? 'block' : 'none';
+			gId('rlc').style.display = d.Sf.RE.checked ? 'block' : 'none';
 		}
 		// reset remotes: initialize empty list (called from xml.cpp)
 		function rstR() {
 			gId('rml').innerHTML = ''; // clear remote list
-			rC = 0;
-			uR(); // update remote list
 		}
 		// add remote MAC to the list
 		function aR(id, mac) {
 			if (!/^[0-9A-F]{12}$/i.test(mac)) return; // check for valid hex string
-			if (rC >= 10) return;
 			let inputs = d.querySelectorAll("#rml input");
 			for (let i of (inputs || [])) {
 				if (i.value === mac) return;
 			}
 			let l = gId('rml'), r = cE('div'), i = cE('input');
-			i.type = 'text'; i.name = id; i.value = mac; i.maxLength = 12; i.minLength = 12; i.onchange = uR;
+			i.type = 'text';
+			i.name = id;
+			i.value = mac;
+			i.maxLength = 12;
+			i.minLength = 12;
+			//i.onchange = uR;
 			r.appendChild(i);
 			let b = cE('button');
-			b.type = 'button'; b.innerText = '-'; b.onclick = () => rR(r);
+			b.type = 'button';
+			b.className = 'sml';
+			b.innerText = '-';
+			b.onclick = (e) => {
+ 				r.remove();
+ 			};
 			r.appendChild(b);
 			l.appendChild(r);
 			rC++;
-			uR();
+			gId('+').style.display = gId("rml").childElementCount < 10 ? 'inline' : 'none'; // can't append to list anymore, hide button
 		}
-		// remove a remote from the list
-		function rR(e) {
-			e.remove();
-			uR();
-		}
-		// update remote list
-		function uR() {
-			let macs = [];
-			d.querySelectorAll('#rml input').forEach(o => {
-				if (o.value) macs.push(o.value);
-			});
-			gId('rmacs').value = JSON.stringify(macs);
-			return true; // Allow form submission to continue
-		}
+
 	</script>
 	<style>@import url("style.css");</style>
 </head>
 <body onload="S()">
-  <form id="form_s" name="Sf" method="post" onsubmit="return uR()">
+  <form id="form_s" name="Sf" method="post">
 		<div class="toprow">
 		<div class="helpB"><button type="button" onclick="H('features/settings/#wifi-settings')">?</button></div>
 		<button type="button" onclick="B()">Back</button><button type="submit">Save & Connect</button><hr>
@@ -255,12 +247,11 @@ Static subnet mask:<br>
 			Keep disabled if not using a remote or wireless sync, increases power consumption.<br></i>
 			<div id="rlc">
 				Last device seen: <span class="rlid" id="ld">None</span>
-				<button type="button" onclick="aR('RM'+rC,gId('ld').textContent)">+</button><br>
+				<button type="button" class="sml" id="+" onclick="aR('RM'+rC,gId('ld').textContent)">+</button><br>
 				Linked MACs:<br>
 				<div id="rml">
 				</div>
 			</div>
-			<input type="hidden" name="RMA" id="rmacs">
 		</div>
 
 		<div id="ethd">

--- a/wled00/remote.cpp
+++ b/wled00/remote.cpp
@@ -181,15 +181,9 @@ static bool remoteJson(int button)
   return parsed;
 }
 
-// Callback function that will be executed when data is received
+// Callback function that will be executed when data is received from a linked remote
 void handleWiZdata(uint8_t *incomingData, size_t len) {
   message_structure_t *incoming = reinterpret_cast<message_structure_t *>(incomingData);
-
-  if (strcmp(last_signal_src, linked_remote) != 0) {
-    DEBUG_PRINT(F("ESP Now Message Received from Unlinked Sender: "));
-    DEBUG_PRINTLN(last_signal_src);
-    return;
-  }
 
   if (len != sizeof(message_structure_t)) {
     DEBUG_PRINTF_P(PSTR("Unknown incoming ESP Now message received of length %u\n"), len);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -91,8 +91,22 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     bool oldESPNow = enableESPNow;
     enableESPNow = request->hasArg(F("RE"));
     if (oldESPNow != enableESPNow) forceReconnect = true;
-    strlcpy(linked_remote, request->arg(F("RMAC")).c_str(), 13);
-    strlwr(linked_remote);  //Normalize MAC format to lowercase
+    linked_remotes.clear();  // clear old remotes
+    for (size_t n = 0; n < 10; n++) {
+      char rm[4];
+      snprintf(rm, sizeof(rm), "RM%d", n); // "RM0" to "RM9"
+      if (request->hasArg(rm)) {
+        Serial.printf_P(PSTR("Adding remote %s\n"), request->arg(rm).c_str());//!!!
+        const String& arg = request->arg(rm);
+        if (arg.isEmpty()) continue;
+        std::array<char, 13> mac{};
+        strlcpy(mac.data(), request->arg(rm).c_str(), 13);
+        strlwr(mac.data());
+        if (mac[0] != '\0') {
+          linked_remotes.push_back(mac);
+        }
+      }
+    }
     #endif
 
     #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_ETHERNET)

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -96,7 +96,6 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       char rm[4];
       snprintf(rm, sizeof(rm), "RM%d", n); // "RM0" to "RM9"
       if (request->hasArg(rm)) {
-        Serial.printf_P(PSTR("Adding remote %s\n"), request->arg(rm).c_str());//!!!
         const String& arg = request->arg(rm);
         if (arg.isEmpty()) continue;
         std::array<char, 13> mac{};

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -102,7 +102,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
         strlcpy(mac.data(), request->arg(rm).c_str(), 13);
         strlwr(mac.data());
         if (mac[0] != '\0') {
-          linked_remotes.push_back(mac);
+          linked_remotes.emplace_back(mac);
         }
       }
     }

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -959,14 +959,22 @@ void espNowReceiveCB(uint8_t* address, uint8_t* data, uint8_t len, signed int rs
   // usermods hook can override processing
   if (UsermodManager::onEspNowMessage(address, data, len)) return;
 
-  // handle WiZ Mote data
-  if (data[0] == 0x91 || data[0] == 0x81 || data[0] == 0x80) {
-    handleWiZdata(data, len);
+  bool knownRemote = false;
+  for (const auto& mac : linked_remotes) {
+    if (strlen(mac.data()) == 12 && strcmp(last_signal_src, mac.data()) == 0) {
+      knownRemote = true;
+      break;
+    }
+  }
+  if (!knownRemote) {
+    DEBUG_PRINT(F("ESP Now Message Received from Unlinked Sender: "));
+    DEBUG_PRINTLN(last_signal_src);
     return;
   }
 
-  if (strlen(linked_remote) == 12 && strcmp(last_signal_src, linked_remote) != 0) {
-    DEBUG_PRINTLN(F("ESP-NOW unpaired remote sender."));
+  // handle WiZ Mote data
+  if (data[0] == 0x91 || data[0] == 0x81 || data[0] == 0x80) {
+    handleWiZdata(data, len);
     return;
   }
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -538,7 +538,8 @@ WLED_GLOBAL bool     serialCanTX _INIT(false);
 WLED_GLOBAL bool enableESPNow        _INIT(false);  // global on/off for ESP-NOW
 WLED_GLOBAL byte statusESPNow        _INIT(ESP_NOW_STATE_UNINIT); // state of ESP-NOW stack (0 uninitialised, 1 initialised, 2 error)
 WLED_GLOBAL bool useESPNowSync       _INIT(false);  // use ESP-NOW wireless technology for sync
-WLED_GLOBAL char linked_remote[13]   _INIT("");     // MAC of ESP-NOW remote (Wiz Mote)
+//WLED_GLOBAL char linked_remote[13]   _INIT("");     // MAC of ESP-NOW remote (Wiz Mote)
+WLED_GLOBAL std::vector<std::array<char, 13>> linked_remotes; // MAC of ESP-NOW remotes (Wiz Mote)
 WLED_GLOBAL char last_signal_src[13] _INIT("");     // last seen ESP-NOW sender
 #endif
 

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -220,6 +220,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     for (size_t i = 0; i < linked_remotes.size(); i++) {
       settingsScript.printf_P(PSTR("aR(\"RM%u\",\"%s\");"), i, linked_remotes[i].data()); // add remote to list
     }
+    settingsScript.print(F("tE();")); // fill fields
     #else
     //hide remote settings if not compiled
     settingsScript.print(F("toggle('ESPNOW');"));  // hide ESP-NOW setting

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -216,7 +216,10 @@ void getSettingsJS(byte subPage, Print& settingsScript)
 
     #ifndef WLED_DISABLE_ESPNOW
     printSetFormCheckbox(settingsScript,PSTR("RE"),enableESPNow);
-    printSetFormValue(settingsScript,PSTR("RMAC"),linked_remote);
+    settingsScript.printf_P(PSTR("resetRemotes();"));
+    for (size_t i = 0; i < linked_remotes.size(); i++) {
+      settingsScript.printf_P(PSTR("addRemote(\"RM%u\",\"%s\");"), i, linked_remotes[i].data());
+    }
     #else
     //hide remote settings if not compiled
     settingsScript.print(F("toggle('ESPNOW');"));  // hide ESP-NOW setting

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -216,9 +216,9 @@ void getSettingsJS(byte subPage, Print& settingsScript)
 
     #ifndef WLED_DISABLE_ESPNOW
     printSetFormCheckbox(settingsScript,PSTR("RE"),enableESPNow);
-    settingsScript.printf_P(PSTR("resetRemotes();"));
+    settingsScript.printf_P(PSTR("rstR();")); // reset remote list
     for (size_t i = 0; i < linked_remotes.size(); i++) {
-      settingsScript.printf_P(PSTR("addRemote(\"RM%u\",\"%s\");"), i, linked_remotes[i].data());
+      settingsScript.printf_P(PSTR("aR(\"RM%u\",\"%s\");"), i, linked_remotes[i].data()); // add remote to list
     }
     #else
     //hide remote settings if not compiled
@@ -261,10 +261,6 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     #ifndef WLED_DISABLE_ESPNOW
     if (strlen(last_signal_src) > 0) { //Have seen an ESP-NOW Remote
       printSetClassElementHTML(settingsScript,PSTR("rlid"),0,last_signal_src);
-    } else if (!enableESPNow) {
-      printSetClassElementHTML(settingsScript,PSTR("rlid"),0,(char*)F("(Enable ESP-NOW to listen)"));
-    } else {
-      printSetClassElementHTML(settingsScript,PSTR("rlid"),0,(char*)F("None"));
     }
     #endif
   }


### PR DESCRIPTION
- upgraded ESPNow remotes to a vector array
- changed config to support arrays
- updated wifi settings page to:
  - display the list of linked remotes
  - add last seen remote to the list
  - limit to 10 remotes max
  - send out the list of remots as "RM0" to "RM9"
  
Since I have very little knowledge on HTML and java script I did the UI update with a lot of help from AI's. 
Please check the code for any mistakes or possible improvements. I tested it and it does work but I really do not know if there is better ways to do the java part.

![image](https://github.com/user-attachments/assets/37bfcba0-19c4-4a29-9210-3eab3908ffe9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for managing multiple ESP-NOW remote MAC addresses in the WiFi settings, replacing the previous single-remote limitation.
  - Introduced a new user interface for adding, removing, and listing up to 10 ESP-NOW remotes directly from the settings page.

- **Bug Fixes**
  - Improved handling and validation of remote MAC addresses to prevent duplicates and enforce limits.
  - Enhanced message processing to accept ESP-NOW data only from authorized linked remotes.

- **Refactor**
  - Updated internal logic to store and process multiple remote devices, enhancing flexibility for advanced users.
  - Removed legacy single-remote filtering to support multiple remotes seamlessly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->