### PR TITLE
bugfix in enumerating buttons and busses

### DIFF
--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -146,7 +146,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 
     bool busesChanged = false;
     for (int s = 0; s < 36; s++) { // theoretical limit is 36 : "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-      int offset = s < 10 ? '0' : 'A';
+      int offset = s < 10 ? '0' : 'A' - 10;
       char lp[4] = "L0"; lp[2] = offset+s; lp[3] = 0; //ascii 0-9 //strip data pin
       char lc[4] = "LC"; lc[2] = offset+s; lc[3] = 0; //strip length
       char co[4] = "CO"; co[2] = offset+s; co[3] = 0; //strip color order
@@ -220,7 +220,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     // we will not bother with pre-allocating ColorOrderMappings vector
     BusManager::getColorOrderMap().reset();
     for (int s = 0; s < WLED_MAX_COLOR_ORDER_MAPPINGS; s++) {
-      int offset = s < 10 ? '0' : 'A';
+      int offset = s < 10 ? '0' : 'A' - 10;
       char xs[4] = "XS"; xs[2] = offset+s; xs[3] = 0; //start LED
       char xc[4] = "XC"; xc[2] = offset+s; xc[3] = 0; //strip length
       char xo[4] = "XO"; xo[2] = offset+s; xo[3] = 0; //color order
@@ -259,7 +259,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     disablePullUp = (bool)request->hasArg(F("IP"));
     touchThreshold = request->arg(F("TT")).toInt();
     for (int i = 0; i < WLED_MAX_BUTTONS; i++) {
-      int offset = i < 10 ? '0' : 'A';
+      int offset = i < 10 ? '0' : 'A' - 10;
       char bt[4] = "BT"; bt[2] = offset+i; bt[3] = 0; // button pin (use A,B,C,... if WLED_MAX_BUTTONS>10)
       char be[4] = "BE"; be[2] = offset+i; be[3] = 0; // button type (use A,B,C,... if WLED_MAX_BUTTONS>10)
       int hw_btn_pin = request->arg(bt).toInt();

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -298,7 +298,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     for (int s = 0; s < BusManager::getNumBusses(); s++) {
       const Bus* bus = BusManager::getBus(s);
       if (!bus || !bus->isOk()) break; // should not happen but for safety
-      int offset = s < 10 ? '0' : 'A';
+      int offset = s < 10 ? '0' : 'A' - 10;
       char lp[4] = "L0"; lp[2] = offset+s; lp[3] = 0; //ascii 0-9 //strip data pin
       char lc[4] = "LC"; lc[2] = offset+s; lc[3] = 0; //strip length
       char co[4] = "CO"; co[2] = offset+s; co[3] = 0; //strip color order


### PR DESCRIPTION
char value was changed from "55" to 'A' which is 65. need to deduct 10 so the result is 'A' if index counter is 10.

@netmindz this bugfix also needs to go into 0.15.x if approved by @blazoncek 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the calculation of parameter key and form element suffix characters for bus indices 10 and above, ensuring correct labeling and display for advanced LED settings. This affects how certain settings are represented in both the user interface and JavaScript output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->