### PR TITLE
Usermod Temperature - added overtemperature protection

### DIFF
--- a/usermods/Temperature/Temperature.cpp
+++ b/usermods/Temperature/Temperature.cpp
@@ -2,7 +2,10 @@
 
 static uint16_t mode_temperature();
 
-void UsermodTemperature::overtempfailure(){
+/**
+ * When overtemperature was triggered and the light is still on, we switch it off to hopefully reduce the temperature
+ */
+void UsermodTemperature::overtempfailure() {
   overtemptriggered = true;
   if(bri >0){
     toggleOnOff();
@@ -10,7 +13,10 @@ void UsermodTemperature::overtempfailure(){
   }
 }
 
-void UsermodTemperature::overtempreset(){
+/**
+ * When the temperature has droped enough we try to turn on the light again
+ */
+void UsermodTemperature::overtempreset() {
   overtemptriggered = false;
   if(bri == 0){
     toggleOnOff();
@@ -18,41 +24,35 @@ void UsermodTemperature::overtempreset(){
   }
 }
 
-
 /**
  * Get auto off Temperature at which WLED Output is swiched off
  */
-int8_t UsermodTemperature::getAutoOffHighThreshold()
-{
+int8_t UsermodTemperature::getAutoOffHighThreshold() {
   return autoOffHighThreshold;
 }
 
 /**
  * Get auto off Temperature at which WLED Output is swiched on again
  */
-int8_t UsermodTemperature::getAutoOffLowThreshold()
-{
+int8_t UsermodTemperature::getAutoOffLowThreshold() {
   return autoOffLowThreshold;
 }
 
 /**
  * Set auto off Temperature at which WLED Output is swiched off 
  */
-void UsermodTemperature::setAutoOffHighThreshold(int8_t threshold)
-{
+void UsermodTemperature::setAutoOffHighThreshold(int8_t threshold) {
   autoOffHighThreshold = min((int8_t)100, max((int8_t)1, threshold));
 }
 
 /**
  * Set auto off Temperature at which WLED Output is swiched on again
  */
-void UsermodTemperature::setAutoOffLowThreshold(int8_t threshold)
-{
+void UsermodTemperature::setAutoOffLowThreshold(int8_t threshold) {
   autoOffLowThreshold = min((int8_t)100, max((int8_t)0, threshold));
   // when low power indicator is enabled the auto-off threshold cannot be above indicator threshold
   autoOffLowThreshold  = autoOffEnabled ? min(autoOffHighThreshold-1, (int)autoOffLowThreshold) : autoOffLowThreshold;
 }
-
 
 //Dallas sensor quick (& dirty) reading. Credit to - Author: Peter Scargill, August 17th, 2013
 float UsermodTemperature::readDallas() {
@@ -221,11 +221,11 @@ void UsermodTemperature::loop() {
     }
     errorCount = 0;
 
-  if(temperature > -100.0f && autoOffEnabled){
-    if (!overtemptriggered && temperature >= autoOffHighThreshold){
+  // Check if we have some kind of temperature reading and then decide to turn off or on the light
+  if(temperature > -100.0f && autoOffEnabled) {
+    if (!overtemptriggered && temperature >= autoOffHighThreshold) {
       overtempfailure();
-    }
-    else if(overtemptriggered && temperature <= autoOffLowThreshold){
+    } else if(overtemptriggered && temperature <= autoOffLowThreshold) {
       overtempreset();
     } 
   }

--- a/usermods/Temperature/Temperature.cpp
+++ b/usermods/Temperature/Temperature.cpp
@@ -53,6 +53,7 @@ void UsermodTemperature::setAutoOffLowThreshold(int8_t threshold)
   autoOffLowThreshold  = autoOffEnabled /*&& autoOffEnabled*/ ? min(autoOffHighThreshold-1, (int)autoOffLowThreshold) : autoOffLowThreshold;
 }
 
+
 //Dallas sensor quick (& dirty) reading. Credit to - Author: Peter Scargill, August 17th, 2013
 float UsermodTemperature::readDallas() {
   byte data[9];
@@ -220,13 +221,14 @@ void UsermodTemperature::loop() {
     }
     errorCount = 0;
 
-    if(temperature > -100.0f && autoOffEnabled){
-      if (!overtemptriggered && temperature >= autoOffHighThreshold){
-        overtempfailure();
-      }
-      else if(overtemptriggered && temperature <= autoOffLowThreshold){
-        overtempreset();
-      } 
+  if(temperature > -100.0f && autoOffEnabled){
+    if (!overtemptriggered && temperature >= autoOffHighThreshold){
+      overtempfailure();
+    }
+    else if(overtemptriggered && temperature <= autoOffLowThreshold){
+      overtempreset();
+    } 
+  }
 
 #ifndef WLED_DISABLE_MQTT
     if (WLED_MQTT_CONNECTED) {

--- a/usermods/Temperature/Temperature.cpp
+++ b/usermods/Temperature/Temperature.cpp
@@ -50,7 +50,7 @@ void UsermodTemperature::setAutoOffLowThreshold(int8_t threshold)
 {
   autoOffLowThreshold = min((int8_t)100, max((int8_t)0, threshold));
   // when low power indicator is enabled the auto-off threshold cannot be above indicator threshold
-  autoOffLowThreshold  = autoOffEnabled /*&& autoOffEnabled*/ ? min(autoOffHighThreshold-1, (int)autoOffLowThreshold) : autoOffLowThreshold;
+  autoOffLowThreshold  = autoOffEnabled ? min(autoOffHighThreshold-1, (int)autoOffLowThreshold) : autoOffLowThreshold;
 }
 
 

--- a/usermods/Temperature/UsermodTemperature.h
+++ b/usermods/Temperature/UsermodTemperature.h
@@ -16,6 +16,18 @@
 #define USERMOD_DALLASTEMPERATURE_MEASUREMENT_INTERVAL 60000
 #endif
 
+#ifndef USERMOD_DALLASTEMPERATURE_AUTO_OFF_HIGH_THRESHOLD
+  #define USERMOD_DALLASTEMPERATURE_AUTO_OFF_HIGH_THRESHOLD 60
+#endif
+
+#ifndef USERMOD_DALLASTEMPERATURE_AUTO_OFF_LOW_THRESHOLD
+  #define USERMOD_DALLASTEMPERATURE_AUTO_OFF_LOW_THRESHOLD 40
+#endif
+
+#ifndef USERMOD_DALLASTEMPERATURE_AUTO_TEMPERATURE_OFF_ENABLED
+  #define USERMOD_DALLASTEMPERATURE_AUTO_TEMPERATURE_OFF_ENABLED true
+#endif
+
 class UsermodTemperature : public Usermod {
 
   private:
@@ -49,6 +61,16 @@ class UsermodTemperature : public Usermod {
     bool HApublished = false;
     int16_t idx = -1;   // Domoticz virtual sensor idx
 
+    // Temperature limits for master off feature
+    uint8_t autoOffHighThreshold = USERMOD_DALLASTEMPERATURE_AUTO_OFF_HIGH_THRESHOLD;
+    uint8_t autoOffLowThreshold = USERMOD_DALLASTEMPERATURE_AUTO_OFF_LOW_THRESHOLD;
+
+    // Has an overtemperature event occured ?
+    bool overtemptriggered = false;
+
+    // auto shutdown/shutoff/master off feature
+    bool autoOffEnabled =   USERMOD_DALLASTEMPERATURE_AUTO_TEMPERATURE_OFF_ENABLED;
+
     // strings to reduce flash memory usage (used more than twice)
     static const char _name[];
     static const char _enabled[];
@@ -60,6 +82,9 @@ class UsermodTemperature : public Usermod {
     static const char _temperature[];
     static const char _Temperature[];
     static const char _data_fx[];
+    static const char _ao[];
+    static const char _thresholdhigh[];
+    static const char _thresholdlow[];
     
     //Dallas sensor quick (& dirty) reading. Credit to - Author: Peter Scargill, August 17th, 2013
     float readDallas();
@@ -104,5 +129,12 @@ class UsermodTemperature : public Usermod {
     bool readFromConfig(JsonObject &root) override;
 
     void appendConfigData() override;
+
+    void overtempfailure();
+    void overtempreset();
+    int8_t getAutoOffHighThreshold();
+    int8_t getAutoOffLowThreshold();
+    void setAutoOffHighThreshold(int8_t threshold);
+    void setAutoOffLowThreshold(int8_t threshold);
 };
 

--- a/usermods/Temperature/UsermodTemperature.h
+++ b/usermods/Temperature/UsermodTemperature.h
@@ -58,18 +58,17 @@ class UsermodTemperature : public Usermod {
 
     bool enabled = true;
 
-    bool HApublished = false;
-    int16_t idx = -1;   // Domoticz virtual sensor idx
-
     // Temperature limits for master off feature
     uint8_t autoOffHighThreshold = USERMOD_DALLASTEMPERATURE_AUTO_OFF_HIGH_THRESHOLD;
     uint8_t autoOffLowThreshold = USERMOD_DALLASTEMPERATURE_AUTO_OFF_LOW_THRESHOLD;
-
     // Has an overtemperature event occured ?
     bool overtemptriggered = false;
-
     // auto shutdown/shutoff/master off feature
     bool autoOffEnabled =   USERMOD_DALLASTEMPERATURE_AUTO_TEMPERATURE_OFF_ENABLED;
+    
+
+    bool HApublished = false;
+    int16_t idx = -1;   // Domoticz virtual sensor idx
 
     // strings to reduce flash memory usage (used more than twice)
     static const char _name[];
@@ -137,4 +136,3 @@ class UsermodTemperature : public Usermod {
     void setAutoOffHighThreshold(int8_t threshold);
     void setAutoOffLowThreshold(int8_t threshold);
 };
-


### PR DESCRIPTION
Added configurable overtemperature protection feature.
2 Settings for upper and lower limit with hysteresis.
Feature can be disabled and is configureable via compiler defines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added overtemperature protection with automatic shutdown and restart based on configurable temperature thresholds.
  - Introduced new settings in the configuration UI to enable/disable overtemperature protection and adjust high and low temperature thresholds.
  - Enhanced configuration persistence to save and restore overtemperature protection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->