### PR TITLE
fix for https://github.com/wled/WLED/issues/4488

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -782,11 +782,9 @@ void IRAM_ATTR_YN Segment::setPixelColor(int i, uint32_t col) const
     // check if this is a virtual strip
     #ifndef WLED_DISABLE_2D
     vStrip = i>>16; // hack to allow running on virtual strips (2D segment columns/rows)
-    i &= 0xFFFF;    //truncate vstrip index
-    if (i >= vL) return;  // if pixel would still fall out of segment just exit
-    #else
-    return;
     #endif
+    i &= 0xFFFF;          // truncate vstrip index. note: vStrip index is 1 even in 1D, still need to truncate
+    if (i >= vL) return;  // if pixel would still fall out of segment just exit
   }
 
 #ifndef WLED_DISABLE_2D


### PR DESCRIPTION
virtual strip index is added even if strip is 1D. this change fixes FX using virtual strips not working when WLED_DISABLE_2D is used.

I recommend waiting to merge this until segment layering PR is merged.