### PR TITLE
Change to set LWT only once

### DIFF
--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -27,7 +27,7 @@ static void parseMQTTBriPayload(char* payload)
 static void onMqttConnect(bool sessionPresent)
 {
   //(re)subscribe to required topics
-  char subuf[MQTT_MAX_TOPIC_LEN + 6];
+  char subuf[MQTT_MAX_TOPIC_LEN + 9];
 
   if (mqttDeviceTopic[0] != 0) {
     strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
@@ -52,6 +52,13 @@ static void onMqttConnect(bool sessionPresent)
   UsermodManager::onMqttConnect(sessionPresent);
 
   DEBUG_PRINTLN(F("MQTT ready"));
+
+#ifndef USERMOD_SMARTNEST
+  strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
+  strcat_P(subuf, PSTR("/status"));
+  mqtt->publish(subuf, 0, true, "online"); // retain message for a LWT
+#endif
+
   publishMqtt();
 }
 
@@ -173,10 +180,6 @@ void publishMqtt()
   strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
   strcat_P(subuf, PSTR("/c"));
   mqtt->publish(subuf, 0, retainMqttMsg, s);         // optionally retain message (#2263)
-
-  strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
-  strcat_P(subuf, PSTR("/status"));
-  mqtt->publish(subuf, 0, true, "online");          // retain message for a LWT
 
   // TODO: use a DynamicBufferList.  Requires a list-read-capable MQTT client API.
   DynamicBuffer buf(1024);


### PR DESCRIPTION
This moves MQTT publishing of `"online"` to the `/status` topic from the regular [publishMqtt()](https://github.com/wled/WLED/blob/main/wled00/mqtt.cpp#L179) to [onMqttConnect()](https://github.com/wled/WLED/blob/main/wled00/mqtt.cpp#L27).

This way the LWT topic is only set on restart and after wifi or the MQTT connection was lost.

If you track the LWT topic then any change now indicates trouble (wifi lost, reboot, …).

*Implementation details:* 
- `onMqttConnect()s` `subuf` increased by 3 chars as `"/status"` is 3 chars longer than `"/col"`/`"/api"`. Although I think one char less would suffice.
- Publishing of `/status` is not done if `USERMOD_SMARTNEST` is defined, same as before this PR.
- Publishing of `/status` is after `UsermodManager::onMqttConnect()` hooks, same as before this PR. Although I think we could reasonably set it earlier.