### PR TITLE
Fix the behavior of the status LED

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -866,15 +866,19 @@ void WLED::handleStatusLED()
   }
   #endif
 
-  if (WLED_CONNECTED) {
+  if (!WLED_CONNECTED) {
     c = RGBW32(0,255,0,0);
     ledStatusType = 2;
-  } else if (WLED_MQTT_CONNECTED) {
+  #ifndef WLED_DISABLE_MQTT  
+  } else if (mqttEnabled && !WLED_MQTT_CONNECTED) {
     c = RGBW32(0,128,0,0);
     ledStatusType = 4;
+  #endif
   } else if (apActive) {
     c = RGBW32(0,0,255,0);
     ledStatusType = 1;
+  } else {
+    ledStatusType = 0;
   }
   if (ledStatusType) {
     if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {


### PR DESCRIPTION
 This patch fixes the behavior of the status LED to what is described in the code:
```
// If status LED pin is allocated for other uses, does nothing
// else blink at 1Hz when WLED_CONNECTED is false (no WiFi, ?? no Ethernet ??)
// else blink at 2Hz when MQTT is enabled but not connected
// else turn the status LED off
```
1. This is not what the code did, the code checked for 
  * WLED_CONNECTED is true
  * MQTT is connected
  If these were met the LED blinked, you would expect the LED to blink if either or both were not connected.
2. If MQTT was compiled in but not enabled, the check if it was connected always failed (of course) and the LED would blink.
3. The blink status was never reset if a connection was establiched after some time.

I think this has been wrong in the code for a long time, fixed it whenever i had a project using the status LED but never thought of submitting the patch, well here it is in all it's glory 🤣 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status LED behavior to more accurately reflect device connection and MQTT states with distinct colors and blink rates.
  - Ensured the status LED turns off when no specific status condition is met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->