### PR TITLE
fix particle brightness distribution with new gamma correction

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -533,7 +533,6 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     gammaCorrectCol = false;
   }
   NeoGammaWLEDMethod::calcGammaTable(gammaCorrectVal); // fill look-up tables
-  NeoGammaWLEDMethod::calcInverseGammaTable(gammaCorrectVal);
 
   JsonObject light_tr = light["tr"];
   int tdd = light_tr["dur"] | -1;

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -532,7 +532,8 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     gammaCorrectBri = false;
     gammaCorrectCol = false;
   }
-  NeoGammaWLEDMethod::calcGammaTable(gammaCorrectVal); // fill look-up table
+  NeoGammaWLEDMethod::calcGammaTable(gammaCorrectVal); // fill look-up tables
+  NeoGammaWLEDMethod::calcInverseGammaTable(gammaCorrectVal);
 
   JsonObject light_tr = light["tr"];
   int tdd = light_tr["dur"] | -1;

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -564,14 +564,22 @@ uint16_t approximateKelvinFromRGB(uint32_t rgb) {
   }
 }
 
-// gamma lookup table used for color correction (filled on 1st use (cfg.cpp & set.cpp))
+// gamma lookup tables used for color correction (filled on 1st use (cfg.cpp & set.cpp))
 uint8_t NeoGammaWLEDMethod::gammaT[256];
+uint8_t NeoGammaWLEDMethod::gammaT_inv[256];
 
-// re-calculates & fills gamma table
+// re-calculates & fills gamma tables
 void NeoGammaWLEDMethod::calcGammaTable(float gamma)
 {
   for (size_t i = 0; i < 256; i++) {
     gammaT[i] = (int)(powf((float)i / 255.0f, gamma) * 255.0f + 0.5f);
+  }
+}
+
+void NeoGammaWLEDMethod::calcInverseGammaTable(float gamma)
+{
+  for (size_t i = 0; i < 256; i++) {
+    gammaT_inv[i] = (int)(powf((float)i / 255.0f, 1/gamma) * 255.0f + 0.5f); //inverse
   }
 }
 

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -571,15 +571,10 @@ uint8_t NeoGammaWLEDMethod::gammaT_inv[256];
 // re-calculates & fills gamma tables
 void NeoGammaWLEDMethod::calcGammaTable(float gamma)
 {
+  float gamma_inv = 1.0f / gamma; // inverse gamma
   for (size_t i = 0; i < 256; i++) {
     gammaT[i] = (int)(powf((float)i / 255.0f, gamma) * 255.0f + 0.5f);
-  }
-}
-
-void NeoGammaWLEDMethod::calcInverseGammaTable(float gamma)
-{
-  for (size_t i = 0; i < 256; i++) {
-    gammaT_inv[i] = (int)(powf((float)i / 255.0f, 1/gamma) * 255.0f + 0.5f); //inverse
+    gammaT_inv[i] = (int)(powf((float)i / 255.0f, gamma_inv) * 255.0f + 0.5f);
   }
 }
 

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -158,8 +158,7 @@ class NeoGammaWLEDMethod {
   public:
     [[gnu::hot]] static uint8_t Correct(uint8_t value);         // apply Gamma to single channel
     [[gnu::hot]] static uint32_t Correct32(uint32_t color);     // apply Gamma to RGBW32 color (WLED specific, not used by NPB)
-    static void calcGammaTable(float gamma);                              // re-calculates & fills gamma table
-    static void calcInverseGammaTable(float gamma);                       // re-calculates & fills inverse gamma table
+    static void calcGammaTable(float gamma);                    // re-calculates & fills gamma tables
     static inline uint8_t rawGamma8(uint8_t val) { return gammaT[val]; }  // get value from Gamma table (WLED specific, not used by NPB)
     static inline uint8_t rawInverseGamma8(uint8_t val) { return gammaT_inv[val]; }  // get value from inverse Gamma table (WLED specific, not used by NPB)
   private:

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -159,12 +159,16 @@ class NeoGammaWLEDMethod {
     [[gnu::hot]] static uint8_t Correct(uint8_t value);         // apply Gamma to single channel
     [[gnu::hot]] static uint32_t Correct32(uint32_t color);     // apply Gamma to RGBW32 color (WLED specific, not used by NPB)
     static void calcGammaTable(float gamma);                              // re-calculates & fills gamma table
+    static void calcInverseGammaTable(float gamma);                       // re-calculates & fills inverse gamma table
     static inline uint8_t rawGamma8(uint8_t val) { return gammaT[val]; }  // get value from Gamma table (WLED specific, not used by NPB)
+    static inline uint8_t rawInverseGamma8(uint8_t val) { return gammaT_inv[val]; }  // get value from inverse Gamma table (WLED specific, not used by NPB)
   private:
     static uint8_t gammaT[];
+    static uint8_t gammaT_inv[];
 };
 #define gamma32(c) NeoGammaWLEDMethod::Correct32(c)
 #define gamma8(c)  NeoGammaWLEDMethod::rawGamma8(c)
+#define gamma8inv(c)  NeoGammaWLEDMethod::rawInverseGamma8(c)
 [[gnu::hot, gnu::pure]] uint32_t color_blend(uint32_t c1, uint32_t c2 , uint8_t blend);
 inline uint32_t color_blend16(uint32_t c1, uint32_t c2, uint16_t b) { return color_blend(c1, c2, b >> 8); };
 [[gnu::hot, gnu::pure]] uint32_t color_add(uint32_t, uint32_t, bool preserveCR = false);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -341,7 +341,8 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       gammaCorrectBri = false;
       gammaCorrectCol = false;
     }
-    NeoGammaWLEDMethod::calcGammaTable(gammaCorrectVal); // fill look-up table
+    NeoGammaWLEDMethod::calcGammaTable(gammaCorrectVal); // fill look-up tables
+    NeoGammaWLEDMethod::calcInverseGammaTable(gammaCorrectVal);
 
     t = request->arg(F("TD")).toInt();
     if (t >= 0) transitionDelayDefault = t;

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -342,7 +342,6 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       gammaCorrectCol = false;
     }
     NeoGammaWLEDMethod::calcGammaTable(gammaCorrectVal); // fill look-up tables
-    NeoGammaWLEDMethod::calcInverseGammaTable(gammaCorrectVal);
 
     t = request->arg(F("TD")).toInt();
     if (t >= 0) transitionDelayDefault = t;


### PR DESCRIPTION
Particle System depends on linear brightness distribution, gamma corrected values are non-linear.
- added invers gamma table
- reversing gamma after brightness distribution makes it linear once again

there is no other way to fix this unfortunately. It comes at the cost of a second lookup table (additional 256bytes of RAM used) and a slight hit to FPS in PS effects but its nothing to worry about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved LED particle rendering by introducing inverse gamma correction for more accurate brightness and color representation.

- **Bug Fixes**
  - Enhanced consistency of particle brightness across different modes by applying gamma correction and its inverse during rendering.

- **Chores**
  - Updated internal handling of gamma correction settings to support both gamma and inverse gamma lookup tables for improved visual output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->