### PR TITLE
Add pre-applied gamma to c3g & (some) fastled palettes to match original look

### DIFF
--- a/wled00/palettes.h
+++ b/wled00/palettes.h
@@ -2,106 +2,109 @@
 #define PalettesWLED_h
 
 /*
- * Color palettes for FastLED effects (65-73).
+ * WLED Color palettes
+ *
+ * Note: palettes imported from http://seaviewsensing.com/pub/cpt-city are gamma corrected using gammas (1.182, 1.0, 1.136)
+ *       this is done to match colors of the palettes after applying the (default) global gamma of 2.2 to versions
+ *       prior to WLED 0.16 which used pre-applied gammas of (2.6,2.2,2.5) for these palettes.
+ *       Palettes from FastLED are intended to be used without gamma correction, an inverse gamma of 2.2 is applied to original colors
  */
-
-// From ColorWavesWithPalettes by Mark Kriegsman: https://gist.github.com/kriegsman/8281905786e8b2632aeb
-// Unfortunately, these are stored in RAM!
 
 // Gradient palette "ib_jul01_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/ing/xmas/ib_jul01.c3g
 const uint8_t ib_jul01_gp[] PROGMEM = {
-    0, 230,   6,  17,
-   94,  37,  96,  90,
-  132, 144, 189, 106,
-  255, 187,   3,  13};
+    0, 226,   6,  12,
+   94,  26,  96,  78,
+  132, 130, 189,  94,
+  255, 177,   3,   9};
 
 // Gradient palette "es_vintage_57_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/vintage/es_vintage_57.c3g
 const uint8_t es_vintage_57_gp[] PROGMEM = {
-    0,  41,   8,   5,
-   53,  92,   1,   0,
-  104, 155,  96,  36,
-  153, 217, 191,  72,
-  255, 132, 129,  52};
+    0,  29,   8,   3,
+   53,  76,   1,   0,
+  104, 142,  96,  28,
+  153, 211, 191,  61,
+  255, 117, 129,  42};
 
 // Gradient palette "es_vintage_01_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/vintage/es_vintage_01.c3g
 const uint8_t es_vintage_01_gp[] PROGMEM = {
-    0,  54,  18,  32,
-   51,  89,   0,  30,
-   76, 176, 170,  48,
-  101, 255, 189,  92,
-  127, 153,  56,  50,
-  153,  89,   0,  30,
-  229,  54,  18,  32,
-  255,  54,  18,  32};
+    0,  41,  18,  24,
+   51,  73,   0,  22,
+   76, 165, 170,  38,
+  101, 255, 189,  80,
+  127, 139,  56,  40,
+  153,  73,   0,  22,
+  229,  41,  18,  24,
+  255,  41,  18,  24};
 
 // Gradient palette "es_rivendell_15_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/rivendell/es_rivendell_15.c3g
 const uint8_t es_rivendell_15_gp[] PROGMEM = {
-    0,  35,  69,  54,
-  101,  88, 105,  82,
-  165, 143, 140, 109,
-  242, 208, 204, 175,
-  255, 208, 204, 175};
+    0,  24,  69,  44,
+  101,  73, 105,  70,
+  165, 129, 140,  97,
+  242, 200, 204, 166,
+  255, 200, 204, 166};
 
 // Gradient palette "rgi_15_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/ds/rgi/rgi_15.c3g
 const uint8_t rgi_15_gp[] PROGMEM = {
-    0,  54,  14, 111,
-   31, 142,  24,  86,
-   63, 231,  34,  61,
-   95, 146,  31,  88,
-  127,  61,  29, 114,
-  159, 124,  47, 113,
-  191, 186,  66, 112,
-  223, 143,  57, 116,
-  255, 100,  48, 120};
+    0,  41,  14,  99,
+   31, 128,  24,  74,
+   63, 227,  34,  50,
+   95, 132,  31,  76,
+  127,  47,  29, 102,
+  159, 109,  47, 101,
+  191, 176,  66, 100,
+  223, 129,  57, 104,
+  255,  84,  48, 108};
 
 // Gradient palette "retro2_16_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/ma/retro2/retro2_16.c3g
 const uint8_t retro2_16_gp[] PROGMEM = {
-    0, 227, 191,  12,
-  255, 132,  52,   2};
+    0, 222, 191,   8,
+  255, 117,  52,   1};
 
 // Gradient palette "Analogous_1_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/red/Analogous_1.c3g
 const uint8_t Analogous_1_gp[] PROGMEM = {
-    0,  51,   0, 255,
-   63, 102,   0, 255,
-  127, 153,   0, 255,
-  191, 204,   0, 128,
+    0,  38,   0, 255,
+   63,  86,   0, 255,
+  127, 139,   0, 255,
+  191, 196,   0, 117,
   255, 255,   0,   0};
 
 // Gradient palette "es_pinksplash_08_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/pink_splash/es_pinksplash_08.c3g
 const uint8_t es_pinksplash_08_gp[] PROGMEM = {
-    0, 195,  63, 255,
-  127, 231,   9,  97,
-  175, 237, 205, 218,
-  221, 212,  38, 184,
-  255, 212,  38, 184};
+    0, 186,  63, 255,
+  127, 227,   9,  85,
+  175, 234, 205, 213,
+  221, 205,  38, 176,
+  255, 205,  38, 176,
+};
 
 // Gradient palette "es_ocean_breeze_036_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/ocean_breeze/es_ocean_breeze_036.c3g
 const uint8_t es_ocean_breeze_036_gp[] PROGMEM = {
-    0,  25,  48,  62,
-   89,  38, 166, 183,
-  153, 205, 233, 255,
-  255,   0, 145, 162};
+    0,  16,  48,  51,
+   89,  27, 166, 175,
+  153, 197, 233, 255,
+  255,   0, 145, 152};
 
 // Gradient palette "departure_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/mjf/departure.c3g
 const uint8_t departure_gp[] PROGMEM = {
-    0,  68,  34,   0,
-   42, 102,  51,   0,
-   63, 160, 108,  60,
-   84, 218, 166, 120,
-  106, 238, 212, 188,
+    0,  53,  34,   0,
+   42,  86,  51,   0,
+   63, 147, 108,  49,
+   84, 212, 166, 108,
+  106, 235, 212, 180,
   116, 255, 255, 255,
-  138, 200, 255, 200,
-  148, 100, 255, 100,
+  138, 191, 255, 193,
+  148,  84, 255,  88,
   170,   0, 255,   0,
   191,   0, 192,   0,
   212,   0, 128,   0,
@@ -111,227 +114,227 @@ const uint8_t departure_gp[] PROGMEM = {
 // http://seaviewsensing.com/pub/cpt-city/es/landscape/es_landscape_64.c3g
 const uint8_t es_landscape_64_gp[] PROGMEM = {
     0,   0,   0,   0,
-   37,  43,  89,  26,
-   76,  87, 178,  53,
-  127, 163, 235,   8,
-  128, 195, 234, 130,
-  130, 227, 233, 252,
-  153, 205, 219, 234,
-  204, 146, 179, 253,
-  255,  39, 107, 228};
+   37,  31,  89,  19,
+   76,  72, 178,  43,
+  127, 150, 235,   5,
+  128, 186, 234, 119,
+  130, 222, 233, 252,
+  153, 197, 219, 231,
+  204, 132, 179, 253,
+  255,  28, 107, 225};
 
 // Gradient palette "es_landscape_33_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/landscape/es_landscape_33.c3g
 const uint8_t es_landscape_33_gp[] PROGMEM = {
-    0,  19,  45,   0,
-   19, 116,  86,   3,
-   38, 214, 128,   7,
-   63, 245, 197,  25,
-   66, 124, 196, 156,
-  255,   9,  39,  11};
+    0,  12,  45,   0,
+   19, 101,  86,   2,
+   38, 207, 128,   4,
+   63, 243, 197,  18,
+   66, 109, 196, 146,
+  255,   5,  39,   7};
 
 // Gradient palette "rainbowsherbet_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/ma/icecream/rainbowsherbet.c3g
 const uint8_t rainbowsherbet_gp[] PROGMEM = {
-    0, 255, 102,  51,
-   43, 255, 140, 102,
-   86, 255,  51, 102,
-  127, 255, 153, 178,
-  170, 255, 255, 250,
-  209, 128, 255,  97,
-  255, 169, 255, 148};
+    0, 255, 102,  41,
+   43, 255, 140,  90,
+   86, 255,  51,  90,
+  127, 255, 153, 169,
+  170, 255, 255, 249,
+  209, 113, 255,  85,
+  255, 157, 255, 137};
 
 // Gradient palette "gr65_hult_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/hult/gr65_hult.c3g
 const uint8_t gr65_hult_gp[] PROGMEM = {
-    0, 252, 216, 252,
+    0, 251, 216, 252,
    48, 255, 192, 255,
-   89, 241,  95, 243,
-  160,  65, 153, 221,
-  216,  34, 184, 182,
-  255,  34, 184, 182};
+   89, 239,  95, 241,
+  160,  51, 153, 217,
+  216,  24, 184, 174,
+  255,  24, 184, 174};
 
 // Gradient palette "gr64_hult_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/hult/gr64_hult.c3g
 const uint8_t gr64_hult_gp[] PROGMEM = {
-    0,  34, 184, 182,
-   66,  14, 162, 160,
-  104, 139, 137,  11,
-  130, 188, 186,  30,
-  150, 139, 137,  11,
-  201,  10, 156, 154,
-  239,   0, 128, 128,
-  255,   0, 128, 128};
+    0,  24, 184, 174,
+   66,   8, 162, 150,
+  104, 124, 137,   7,
+  130, 178, 186,  22,
+  150, 124, 137,   7,
+  201,   6, 156, 144,
+  239,   0, 128, 117,
+  255,   0, 128, 117};
 
 // Gradient palette "GMT_drywet_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/gmt/GMT_drywet.c3g
 const uint8_t GMT_drywet_gp[] PROGMEM = {
-    0, 134,  97,  42,
-   42, 238, 199, 100,
-   84, 180, 238, 135,
-  127,  50, 238, 235,
-  170,  12, 120, 238,
-  212,  38,   1, 183,
-  255,   8,  51, 113};
+    0, 119,  97,  33,
+   42, 235, 199,  88,
+   84, 169, 238, 124,
+  127,  37, 238, 232,
+  170,   7, 120, 236,
+  212,  27,   1, 175,
+  255,   4,  51, 101};
 
 // Gradient palette "ib15_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/ing/general/ib15.c3g
 const uint8_t ib15_gp[] PROGMEM = {
-    0, 187, 160, 205,
-   72, 212, 158, 159,
-   89, 236, 155, 113,
-  107, 255,  95,  74,
-  141, 201,  98, 121,
-  255, 146, 101, 168};
+    0, 177, 160, 199,
+   72, 205, 158, 149,
+   89, 233, 155, 101,
+  107, 255,  95,  63,
+  141, 192,  98, 109,
+  255, 132, 101, 159};
 
 // Gradient palette "Tertiary_01_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/vermillion/Tertiary_01.c3g
 const uint8_t Tertiary_01_gp[] PROGMEM = {
     0,   0,  25, 255,
-   63,  51, 140, 128,
-  127, 102, 255,   0,
-  191, 178, 140,  26,
-  255, 255,  25,  51};
+   63,  38, 140, 117,
+  127,  86, 255,   0,
+  191, 167, 140,  19,
+  255, 255,  25,  41};
 
 // Gradient palette "lava_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/neota/elem/lava.c3g
 const uint8_t lava_gp[] PROGMEM = {
     0,   0,   0,   0,
-   46,  93,   0,   0,
-   96, 187,   0,   0,
-  108, 204,  38,  13,
-  119, 221,  76,  26,
-  146, 238, 115,  38,
-  174, 255, 153,  51,
-  188, 255, 178,  51,
-  202, 255, 204,  51,
-  218, 255, 230,  51,
-  234, 255, 255,  51,
-  244, 255, 255, 153,
+   46,  77,   0,   0,
+   96, 177,   0,   0,
+  108, 196,  38,   9,
+  119, 215,  76,  19,
+  146, 235, 115,  29,
+  174, 255, 153,  41,
+  188, 255, 178,  41,
+  202, 255, 204,  41,
+  218, 255, 230,  41,
+  234, 255, 255,  41,
+  244, 255, 255, 143,
   255, 255, 255, 255};
 
 // Gradient palette "fierce-ice_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/neota/elem/fierce-ice.c3g
 const uint8_t fierce_ice_gp[] PROGMEM = {
     0,   0,   0,   0,
-   59,   0,  51, 128,
+   59,   0,  51, 117,
   119,   0, 102, 255,
-  149,  51, 153, 255,
-  180, 102, 204, 255,
-  217, 178, 230, 255,
+  149,  38, 153, 255,
+  180,  86, 204, 255,
+  217, 167, 230, 255,
   255, 255, 255, 255};
 
 // Gradient palette "Colorfull_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/atmospheric/Colorfull.c3g
 const uint8_t Colorfull_gp[] PROGMEM = {
-    0,  76, 155,  54,
-   25, 111, 174,  89,
-   60, 146, 193, 125,
-   93, 166, 166, 136,
-  106, 185, 138, 147,
-  109, 193, 121, 148,
-  113, 202, 104, 149,
-  116, 229, 179, 174,
-  124, 255, 255, 199,
-  168, 178, 218, 209,
-  255, 100, 182, 219};
+    0,  61, 155,  44,
+   25,  95, 174,  77,
+   60, 132, 193, 113,
+   93, 154, 166, 125,
+  106, 175, 138, 136,
+  109, 183, 121, 137,
+  113, 194, 104, 138,
+  116, 225, 179, 165,
+  124, 255, 255, 192,
+  168, 167, 218, 203,
+  255,  84, 182, 215};
 
 // Gradient palette "Pink_Purple_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/atmospheric/Pink_Purple.c3g
 const uint8_t Pink_Purple_gp[] PROGMEM = {
-    0,  95,  32, 121,
-   25, 106,  40, 128,
-   51, 117,  48, 135,
-   76, 154, 135, 192,
-  102, 190, 222, 249,
-  109, 215, 236, 252,
-  114, 240, 250, 255,
-  122, 213, 200, 241,
-  149, 187, 149, 226,
-  183, 196, 130, 209,
-  255, 206, 111, 191};
+    0,  79,  32, 109,
+   25,  90,  40, 117,
+   51, 102,  48, 124,
+   76, 141, 135, 185,
+  102, 180, 222, 248,
+  109, 208, 236, 252,
+  114, 237, 250, 255,
+  122, 206, 200, 239,
+  149, 177, 149, 222,
+  183, 187, 130, 203,
+  255, 198, 111, 184};
 
 // Gradient palette "Sunset_Real_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/atmospheric/Sunset_Real.c3g
 const uint8_t Sunset_Real_gp[] PROGMEM = {
-    0, 191,   0,   0,
-   22, 223,  85,   0,
+    0, 181,   0,   0,
+   22, 218,  85,   0,
    51, 255, 170,   0,
-   85, 217,  85,  89,
-  135, 178,   0, 178,
-  198,  89,   0, 195,
-  255,   0,   0, 212};
+   85, 211,  85,  77,
+  135, 167,   0, 169,
+  198,  73,   0, 188,
+  255,   0,   0, 207};
 
 // Gradient palette "Sunset_Yellow_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/atmospheric/Sunset_Yellow.c3g
 const uint8_t Sunset_Yellow_gp[] PROGMEM = {
-    0,  76, 135, 191,
-   36, 143, 188, 178,
-   87, 210, 241, 165,
-  100, 232, 237, 151,
-  107, 255, 232, 138,
-  115, 252, 202, 141,
-  120, 249, 172, 144,
-  128, 252, 202, 141,
-  180, 255, 232, 138,
-  223, 255, 242, 131,
-  255, 255, 252, 125};
+    0,  61, 135, 184,
+   36, 129, 188, 169,
+   87, 203, 241, 155,
+  100, 228, 237, 141,
+  107, 255, 232, 127,
+  115, 251, 202, 130,
+  120, 248, 172, 133,
+  128, 251, 202, 130,
+  180, 255, 232, 127,
+  223, 255, 242, 120,
+  255, 255, 252, 113};
 
 // Gradient palette "Beech_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/atmospheric/Beech.c3g
 const uint8_t Beech_gp[] PROGMEM = {
-    0, 255, 254, 238,
-   12, 255, 254, 238,
-   22, 255, 254, 238,
-   26, 228, 224, 186,
-   28, 201, 195, 135,
-   28, 186, 255, 234,
-   50, 138, 251, 238,
-   71,  90, 246, 243,
-   93,  45, 225, 231,
-  120,   0, 204, 219,
-  133,   8, 168, 186,
-  136,  16, 132, 153,
-  136,  65, 189, 217,
-  208,  33, 159, 207,
-  255,   0, 129, 197};
+    0, 255, 254, 236,
+   12, 255, 254, 236,
+   22, 255, 254, 236,
+   26, 223, 224, 178,
+   28, 192, 195, 124,
+   28, 176, 255, 231,
+   50, 123, 251, 236,
+   71,  74, 246, 241,
+   93,  33, 225, 228,
+  120,   0, 204, 215,
+  133,   4, 168, 178,
+  136,  10, 132, 143,
+  136,  51, 189, 212,
+  208,  23, 159, 201,
+  255,   0, 129, 190};
 
 // Gradient palette "Another_Sunset_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/atmospheric/Another_Sunset.c3g
 const uint8_t Another_Sunset_gp[] PROGMEM = {
-    0, 185, 121,  73,
-   29, 142, 103,  71,
-   68, 100,  84,  69,
-   68, 249, 184,  66,
-   97, 241, 204, 105,
-  124, 234, 225, 144,
-  178, 117, 125, 140,
-  255,   0,  26, 136};
+    0, 175, 121,  62,
+   29, 128, 103,  60,
+   68,  84,  84,  58,
+   68, 248, 184,  55,
+   97, 239, 204,  93,
+  124, 230, 225, 133,
+  178, 102, 125, 129,
+  255,   0,  26, 125};
 
 // Gradient palette "es_autumn_19_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/es/autumn/es_autumn_19.c3g
 const uint8_t es_autumn_19_gp[] PROGMEM = {
-    0, 106,  14,   8,
-   51, 153,  41,  19,
-   84, 190,  70,  24,
-  104, 201, 202, 136,
-  112, 187, 137,   5,
-  122, 199, 200, 142,
-  124, 201, 202, 135,
-  135, 187, 137,   5,
-  142, 202, 203, 129,
-  163, 187,  68,  24,
-  204, 142,  35,  17,
-  249,  90,   5,   4,
-  255,  90,   5,   4};
+    0,  90,  14,   5,
+   51, 139,  41,  13,
+   84, 180,  70,  17,
+  104, 192, 202, 125,
+  112, 177, 137,   3,
+  122, 190, 200, 131,
+  124, 192, 202, 124,
+  135, 177, 137,   3,
+  142, 194, 203, 118,
+  163, 177,  68,  17,
+  204, 128,  35,  12,
+  249,  74,   5,   2,
+  255,  74,   5,   2};
 
 // Gradient palette "BlacK_Blue_Magenta_White_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/basic/BlacK_Blue_Magenta_White.c3g
 const uint8_t BlacK_Blue_Magenta_White_gp[] PROGMEM = {
     0,   0,   0,   0,
-   42,   0,   0, 128,
+   42,   0,   0, 117,
    84,   0,   0, 255,
-  127, 128,   0, 255,
+  127, 113,   0, 255,
   170, 255,   0, 255,
   212, 255, 128, 255,
   255, 255, 255, 255};
@@ -340,20 +343,20 @@ const uint8_t BlacK_Blue_Magenta_White_gp[] PROGMEM = {
 // http://seaviewsensing.com/pub/cpt-city/nd/basic/BlacK_Magenta_Red.c3g
 const uint8_t BlacK_Magenta_Red_gp[] PROGMEM = {
     0,   0,   0,   0,
-   63, 128,   0, 128,
+   63, 113,   0, 117,
   127, 255,   0, 255,
-  191, 255,   0, 128,
+  191, 255,   0, 117,
   255, 255,   0,   0};
 
 // Gradient palette "BlacK_Red_Magenta_Yellow_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/nd/basic/BlacK_Red_Magenta_Yellow.c3g
 const uint8_t BlacK_Red_Magenta_Yellow_gp[] PROGMEM = {
     0,   0,   0,   0,
-   42, 128,   0,   0,
+   42, 113,   0,   0,
    84, 255,   0,   0,
-  127, 255,   0, 128,
+  127, 255,   0, 117,
   170, 255,   0, 255,
-  212, 255, 128, 128,
+  212, 255, 128, 117,
   255, 255, 255,   0};
 
 // Gradient palette "Blue_Cyan_Yellow_gp", originally from
@@ -362,7 +365,7 @@ const uint8_t Blue_Cyan_Yellow_gp[] PROGMEM = {
     0,   0,   0, 255,
    63,   0, 128, 255,
   127,   0, 255, 255,
-  191, 128, 255, 128,
+  191, 113, 255, 117,
   255, 255, 255,   0};
 
 //Custom palette by Aircoookie
@@ -477,179 +480,181 @@ const byte Atlantica_gp[] PROGMEM = {
 // Gradient palette "temperature_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/arendal/temperature.c3g
 const uint8_t temperature_gp[] PROGMEM = {
-    0,  30,  92, 179,
-   14,  23, 111, 193,
-   28,  11, 142, 216,
-   42,   4, 161, 230,
-   56,  25, 181, 241,
-   70,  51, 188, 207,
-   84, 102, 204, 206,
-   99, 153, 219, 184,
-  113, 192, 229, 136,
-  127, 204, 230,  75,
-  141, 243, 240,  29,
-  155, 254, 222,  39,
-  170, 252, 199,   7,
-  184, 248, 157,  14,
-  198, 245, 114,  21,
-  226, 219,  30,  38,
-  240, 164,  38,  44,
-  255, 164,  38,  44};
+    0,  20,  92, 171,
+   14,  15, 111, 186,
+   28,   6, 142, 211,
+   42,   2, 161, 227,
+   56,  16, 181, 239,
+   70,  38, 188, 201,
+   84,  86, 204, 200,
+   99, 139, 219, 176,
+  113, 182, 229, 125,
+  127, 196, 230,  63,
+  141, 241, 240,  22,
+  155, 254, 222,  30,
+  170, 251, 199,   4,
+  184, 247, 157,   9,
+  198, 243, 114,  15,
+  226, 213,  30,  29,
+  240, 151,  38,  35,
+  255, 151,  38,  35};
 
 // Gradient palette "bhw1_01_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_01.c3g
 const uint8_t retro_clown_gp[] PROGMEM = {
-    0, 244, 168,  48,
-  117, 230,  78,  92,
-  255, 173,  54, 228};
+    0, 242, 168,  38,
+  117, 226,  78,  80,
+  255, 161,  54, 225,
+};
 
 // Gradient palette "bhw1_04_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_04.c3g
 const uint8_t candy_gp[] PROGMEM = {
-    0, 245, 242,  31,
-   15, 244, 168,  48,
-  142, 126,  21, 161,
-  198,  90,  22, 160,
-  255,   0,   0, 128};
+    0, 243, 242,  23,
+   15, 242, 168,  38,
+  142, 111,  21, 151,
+  198,  74,  22, 150,
+  255,   0,   0, 117};
 
 // Gradient palette "bhw1_05_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_05.c3g
 const uint8_t toxy_reaf_gp[] PROGMEM = {
-    0,   5, 239, 137,
-  255, 158,  35, 221};
+    0,   2, 239, 126,
+  255, 145,  35, 217};
 
 // Gradient palette "bhw1_06_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_06.c3g
 const uint8_t fairy_reaf_gp[] PROGMEM = {
-    0, 225,  19, 194,
-  160,  19, 225, 223,
-  219, 210, 242, 227,
+    0, 220,  19, 187,
+  160,  12, 225, 219,
+  219, 203, 242, 223,
   255, 255, 255, 255};
 
 // Gradient palette "bhw1_14_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_14.c3g
 const uint8_t semi_blue_gp[] PROGMEM = {
     0,   0,   0,   0,
-   12,  35,   4,  48,
-   53,  70,   8,  96,
-   80,  56,  48, 168,
-  119,  43,  89, 239,
-  145,  64,  59, 175,
-  186,  86,  30, 110,
-  233,  43,  15,  55,
+   12,  24,   4,  38,
+   53,  55,   8,  84,
+   80,  43,  48, 159,
+  119,  31,  89, 237,
+  145,  50,  59, 166,
+  186,  71,  30,  98,
+  233,  31,  15,  45,
   255,   0,   0,   0};
 
 // Gradient palette "bhw1_three_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_three.c3g
 const uint8_t pink_candy_gp[] PROGMEM = {
     0, 255, 255, 255,
-   45,  64,  64, 255,
-  112, 244,  16, 193,
+   45,  50,  64, 255,
+  112, 242,  16, 186,
   140, 255, 255, 255,
-  155, 244,  16, 193,
-  196, 131,  13, 175,
+  155, 242,  16, 186,
+  196, 116,  13, 166,
   255, 255, 255, 255};
 
 // Gradient palette "bhw1_w00t_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw1/bhw1_w00t.c3g
 const uint8_t red_reaf_gp[] PROGMEM = {
-    0,  49,  68, 126,
-  104, 162, 195, 249,
+    0,  36,  68, 114,
+  104, 149, 195, 248,
   188, 255,   0,   0,
-  255, 110,  14,  14};
+  255,  94,  14,   9};
 
 // Gradient palette "bhw2_23_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw2/bhw2_23.c3g
 const uint8_t aqua_flash_gp[] PROGMEM = {
     0,   0,   0,   0,
-   66, 144, 242, 246,
-   96, 255, 255,  64,
+   66, 130, 242, 245,
+   96, 255, 255,  53,
   124, 255, 255, 255,
-  153, 255, 255,  64,
-  188, 144, 242, 246,
+  153, 255, 255,  53,
+  188, 130, 242, 245,
   255,   0,   0,   0};
 
 // Gradient palette "bhw2_xc_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw2/bhw2_xc.c3g
 const uint8_t yelblu_hot_gp[] PROGMEM = {
-    0,  56,  30,  68,
-   58,  89,   0, 130,
-  122, 103,   0,  86,
-  158, 205,  57,  29,
-  183, 223, 117,  35,
-  219, 241, 177,  41,
-  255, 247, 247,  35};
+    0,  43,  30,  57,
+   58,  73,   0, 119,
+  122,  87,   0,  74,
+  158, 197,  57,  22,
+  183, 218, 117,  27,
+  219, 239, 177,  32,
+  255, 246, 247,  27,
+};
 
 // Gradient palette "bhw2_45_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw2/bhw2_45.c3g
 const uint8_t lite_light_gp[] PROGMEM = {
     0,   0,   0,   0,
-    9,  30,  21,  30,
-   40,  60,  43,  60,
-   66,  60,  43,  60,
-  101,  76,  16,  77,
+    9,  20,  21,  22,
+   40,  46,  43,  49,
+   66,  46,  43,  49,
+  101,  61,  16,  65,
   255,   0,   0,   0};
 
 // Gradient palette "bhw2_22_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw2/bhw2_22.c3g
 const uint8_t red_flash_gp[] PROGMEM = {
     0,   0,   0,   0,
-   99, 244,  12,  12,
-  130, 253, 228, 172,
-  155, 244,  12,  12,
+   99, 242,  12,   8,
+  130, 253, 228, 163,
+  155, 242,  12,   8,
   255,   0,   0,   0};
 
 // Gradient palette "bhw3_40_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw3/bhw3_40.c3g
 const uint8_t blink_red_gp[] PROGMEM = {
-    0,   7,   7,   7,
-   43,  53,  25,  73,
-   76,  76,  15,  46,
-  109, 214,  39, 108,
-  127, 255, 156, 191,
-  165, 194,  73, 212,
-  204, 120,  66, 242,
-  255,  93,  29,  90};
+    0,   4,   7,   4,
+   43,  40,  25,  62,
+   76,  61,  15,  36,
+  109, 207,  39,  96,
+  127, 255, 156, 184,
+  165, 185,  73, 207,
+  204, 105,  66, 240,
+  255,  77,  29,  78};
 
 // Gradient palette "bhw3_52_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw3/bhw3_52.c3g
 const uint8_t red_shift_gp[] PROGMEM = {
-    0, 114,  22, 105,
-   45, 118,  22,  85,
-   99, 201,  45,  67,
-  132, 238, 187,  70,
-  175, 232,  85,  34,
-  201, 232,  56,  59,
-  255,   5,   0,   4};
+    0,  98,  22,  93,
+   45, 103,  22,  73,
+   99, 192,  45,  56,
+  132, 235, 187,  59,
+  175, 228,  85,  26,
+  201, 228,  56,  48,
+  255,   2,   0,   2};
 
 // Gradient palette "bhw4_097_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw4/bhw4_097.c3g
 const uint8_t red_tide_gp[] PROGMEM = {
-    0, 252,  46,   0,
-   28, 255, 139,  33,
-   43, 247, 158,  74,
-   58, 247, 216, 134,
-   84, 245,  94,  15,
-  114, 187,  65,  16,
-  140, 255, 241, 127,
-  168, 187,  65,  16,
-  196, 251, 233, 167,
-  216, 255,  94,   9,
-  255, 140,   8,   6};
+    0, 251,  46,   0,
+   28, 255, 139,  25,
+   43, 246, 158,  63,
+   58, 246, 216, 123,
+   84, 243,  94,  10,
+  114, 177,  65,  11,
+  140, 255, 241, 115,
+  168, 177,  65,  11,
+  196, 250, 233, 158,
+  216, 255,  94,   6,
+  255, 126,   8,   4};
 
 // Gradient palette "bhw4_017_gp", originally from
 // http://seaviewsensing.com/pub/cpt-city/bhw/bhw4/bhw4_017.c3g
 const uint8_t candy2_gp[] PROGMEM = {
-    0, 124, 102, 114,
-   25,  55,  49,  83,
-   48, 136,  96,  96,
-   73, 243, 214,  34,
-   89, 222, 104,  54,
-  130,  55,  49,  83,
-  163, 255, 177,  58,
-  186, 243, 214,  34,
-  211, 124, 102, 114,
-  255,  29,  19,  18};
+    0, 109, 102, 102,
+   25,  42,  49,  71,
+   48, 121,  96,  84,
+   73, 241, 214,  26,
+   89, 216, 104,  44,
+  130,  42,  49,  71,
+  163, 255, 177,  47,
+  186, 241, 214,  26,
+  211, 109, 102, 102,
+  255,  20,  19,  13};
 
 const byte trafficlight_gp[] PROGMEM = {
     0,   0,   0, 0,   //black
@@ -664,15 +669,38 @@ const byte Aurora2_gp[] PROGMEM = {
   192, 250,  77, 127,    //Pink
   255, 171, 101, 221};   //Purple
 
+// FastLed palettes, corrected with inverse gamma of 2.2 to match original looks
+
+// Party colors
+const TProgmemRGBPalette16 PartyColors_gc22 FL_PROGMEM = {
+  0x9B00D5, 0xBD00B8, 0xDA0092, 0xF3005C,
+  0xF45500, 0xDC8F00, 0xD5B400, 0xD5D500,
+  0xD59B00, 0xEF6600, 0xF90044, 0xE10086,
+  0xC400B0, 0xA300CF, 0x7600E8, 0x0032FC};
+
+// Rainbow colors
+const TProgmemRGBPalette16 RainbowColors_gc22 FL_PROGMEM = {
+  0xFF0000, 0xEB7000, 0xD59B00, 0xD5BA00,
+  0xD5D500, 0x9CEB00, 0x00FF00, 0x00EB70,
+  0x00D59B, 0x009CD4, 0x0000FF, 0x7000EB,
+  0x9B00D5, 0xBA00BB, 0xD5009B, 0xEB0072};
+
+// Rainbow colors with alternatating stripes of black
+const TProgmemRGBPalette16 RainbowStripeColors_gc22 FL_PROGMEM = {
+  0xFF0000, 0x000000, 0xD59B00, 0x000000,
+  0xD5D500, 0x000000, 0x00FF00, 0x000000,
+  0x00D59B, 0x000000, 0x0000FF, 0x000000,
+  0x9B00D5, 0x000000, 0xD5009B, 0x000000};
+
 // array of fastled palettes (palette 6 - 12)
 const TProgmemRGBPalette16 *const fastledPalettes[] PROGMEM = {
-  &PartyColors_p,               //06-00 Party
+  &PartyColors_gc22,            //06-00 Party
   &CloudColors_p,               //07-01 Cloud
   &LavaColors_p,                //08-02 Lava
   &OceanColors_p,               //09-03 Ocean
   &ForestColors_p,              //10-04 Forest
-  &RainbowColors_p,             //11-05 Rainbow
-  &RainbowStripeColors_p        //12-06 Rainbow Bands
+  &RainbowColors_gc22,          //11-05 Rainbow
+  &RainbowStripeColors_gc22     //12-06 Rainbow Bands
 };
 
 // Single array of defined cpt-city color palettes.

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -420,7 +420,7 @@ WLED_GLOBAL bool cctICused          _INIT(false); // CCT IC used (Athom 15W bulb
 #endif
 WLED_GLOBAL bool gammaCorrectCol    _INIT(true);  // use gamma correction on colors
 WLED_GLOBAL bool gammaCorrectBri    _INIT(false); // use gamma correction on brightness
-WLED_GLOBAL float gammaCorrectVal   _INIT(2.8f);  // gamma correction value
+WLED_GLOBAL float gammaCorrectVal   _INIT(2.2f);  // gamma correction value
 
 WLED_GLOBAL byte colPri[] _INIT_N(({ 255, 160, 0, 0 }));  // current RGB(W) primary color. colPri[] should be updated if you want to change the color.
 WLED_GLOBAL byte colSec[] _INIT_N(({ 0, 0, 0, 0 }));      // current RGB(W) secondary color


### PR DESCRIPTION
With the new and proper implementation of gamma correction for colors, the palettes imported from http://seaviewsensing.com/pub/cpt-city without any correction by @blazoncek have a slightly different, washed-out look because all three color channels are corrected with the same gamma.
Originally, the palettes were pre-corrected with gammas of 2.6 for red, 2.2 for green and 2.5 for blue. 
In order to match the originals after applying the new default gamma of 2.2 the red and blue channels need a slight pre-correction of 2.6/2.2=1.182 for red and 2.5/2.2=1.136 for blue.

The palettes used from FastLed require an inverse-correction of 2.2 to get a close match to the original looks. I also tried with 1.8 and 1.5 to get something "in between" which also looks quite ok but slightly different. Without any inverse-correction, they do not look good, especially party-colors and rainbow colors. 
FastLed palettes that use HTML colors (clouds, lava, ocean, forest) I left untouched as I think they do look slightly better than the originals, up for discussion.

Also: changed the default value for gamma correction to 2.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three new color palettes with improved gamma correction for more accurate color representation.

- **Improvements**
  - Updated many existing color palettes for better color consistency and accuracy.
  - Adjusted the default gamma correction value for improved color processing.

- **Documentation**
  - Expanded explanations regarding gamma correction and palette handling for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->