### PR TITLE
Fix Segment::fade_out for 2d expansion

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -723,6 +723,13 @@ class Segment {
       return 1;
     #endif
     }
+    inline unsigned rawLength() const {   // returns length of used raw pixel buffer (eg. get/setPixelColorRaw())
+    #ifndef WLED_DISABLE_2D
+      if (is2D()) return virtualWidth() * virtualHeight();
+    #endif
+      return virtualLength();    
+    }
+
   #ifndef WLED_DISABLE_2D
     inline bool is2D() const                                                            { return (width()>1 && height()>1); }
     [[gnu::hot]] void setPixelColorXY(int x, int y, uint32_t c) const; // set relative pixel within segment with color

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -989,7 +989,8 @@ void Segment::fade_out(uint8_t rate) const {
   if (!isActive()) return; // not active
   rate = (256-rate) >> 1;
   const int mappedRate = 256 / (rate + 1);
-  for (unsigned j = 0; j < vLength(); j++) {
+  const size_t length = is2D() ? (vWidth() * vHeight()) : vLength();
+  for (unsigned j = 0; j < length; j++) {
     uint32_t color = getPixelColorRaw(j);
     if (color == colors[1]) continue; // already at target color
     for (int i = 0; i < 32; i += 8) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1038,12 +1038,12 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
 #endif
   uint8_t keep = smear ? 255 : 255 - blur_amount;
   uint8_t seep = blur_amount >> 1;
-  unsigned rlength = rawLength();
+  unsigned vlength = vLength();
   uint32_t carryover = BLACK;
   uint32_t lastnew; // not necessary to initialize lastnew and last, as both will be initialized by the first loop iteration
   uint32_t last;
   uint32_t curnew = BLACK;
-  for (unsigned i = 0; i < rlength; i++) {
+  for (unsigned i = 0; i < vlength; i++) {
     uint32_t cur = getPixelColorRaw(i);
     uint32_t part = color_fade(cur, seep);
     curnew = color_fade(cur, keep);
@@ -1057,7 +1057,7 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
     last = cur; // save original value for comparison on next iteration
     carryover = part;
   }
-  setPixelColorRaw(rlength - 1, curnew);
+  setPixelColorRaw(vlength - 1, curnew);
 }
 
 /*

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -989,8 +989,8 @@ void Segment::fade_out(uint8_t rate) const {
   if (!isActive()) return; // not active
   rate = (256-rate) >> 1;
   const int mappedRate = 256 / (rate + 1);
-  const size_t length = is2D() ? (vWidth() * vHeight()) : vLength();
-  for (unsigned j = 0; j < length; j++) {
+  const size_t rlength = rawLength();  // calculate only once
+  for (unsigned j = 0; j < rlength; j++) {
     uint32_t color = getPixelColorRaw(j);
     if (color == colors[1]) continue; // already at target color
     for (int i = 0; i < 32; i += 8) {
@@ -1011,13 +1011,15 @@ void Segment::fade_out(uint8_t rate) const {
 // fades all pixels to secondary color
 void Segment::fadeToSecondaryBy(uint8_t fadeBy) const {
   if (!isActive() || fadeBy == 0) return;   // optimization - no scaling to apply
-  for (unsigned i = 0; i < vLength(); i++) setPixelColorRaw(i, color_blend(getPixelColorRaw(i), colors[1], fadeBy));
+  const size_t rlength = rawLength();  // calculate only once
+  for (unsigned i = 0; i < rlength; i++) setPixelColorRaw(i, color_blend(getPixelColorRaw(i), colors[1], fadeBy));
 }
 
 // fades all pixels to black using nscale8()
 void Segment::fadeToBlackBy(uint8_t fadeBy) const {
   if (!isActive() || fadeBy == 0) return;   // optimization - no scaling to apply
-  for (unsigned i = 0; i < vLength(); i++) setPixelColorRaw(i, color_fade(getPixelColorRaw(i), 255-fadeBy));
+  const size_t rlength = rawLength();  // calculate only once
+  for (unsigned i = 0; i < rlength; i++) setPixelColorRaw(i, color_fade(getPixelColorRaw(i), 255-fadeBy));
 }
 
 /*
@@ -1036,12 +1038,12 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
 #endif
   uint8_t keep = smear ? 255 : 255 - blur_amount;
   uint8_t seep = blur_amount >> 1;
-  unsigned vlength = vLength();
+  unsigned rlength = rawLength();
   uint32_t carryover = BLACK;
   uint32_t lastnew; // not necessary to initialize lastnew and last, as both will be initialized by the first loop iteration
   uint32_t last;
   uint32_t curnew = BLACK;
-  for (unsigned i = 0; i < vlength; i++) {
+  for (unsigned i = 0; i < rlength; i++) {
     uint32_t cur = getPixelColorRaw(i);
     uint32_t part = color_fade(cur, seep);
     curnew = color_fade(cur, keep);
@@ -1055,7 +1057,7 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
     last = cur; // save original value for comparison on next iteration
     carryover = part;
   }
-  setPixelColorRaw(vlength - 1, curnew);
+  setPixelColorRaw(rlength - 1, curnew);
 }
 
 /*


### PR DESCRIPTION
Ran in to this one during testing last night.   Since we're using get/setPixelColorRaw, we need the true pixel count, not the virtual length.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pixel fading behavior to ensure fade-out covers the entire 2D area for segments, providing more consistent visual effects.
  - Enhanced fade and blur effects by accurately processing the full physical pixel area in segments, resulting in smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->