### PR TITLE
Fixed "Flow Stripe" FX and added palette support

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4817,7 +4817,7 @@ static const char _data_FX_MODE_WAVESINS[] PROGMEM = "Wavesins@!,Brightness vari
 //////////////////////////////
 //     Flow Stripe          //
 //////////////////////////////
-// By: ldirko  https://editor.soulmatelights.com/gallery/392-flow-led-stripe , modifed by: Andrew Tuline
+// By: ldirko  https://editor.soulmatelights.com/gallery/392-flow-led-stripe , modifed by: Andrew Tuline, fixed by @DedeHai
 uint16_t mode_FlowStripe(void) {
   if (SEGLEN <= 1) return mode_static();
   const int hl = SEGLEN * 10 / 13;
@@ -4825,16 +4825,16 @@ uint16_t mode_FlowStripe(void) {
   uint32_t t = strip.now / (SEGMENT.intensity/8+1);
 
   for (unsigned i = 0; i < SEGLEN; i++) {
-    int c = (abs((int)i - hl) / hl) * 127;
+    int c = ((abs((int)i - hl) * 127) / hl);
     c = sin8_t(c);
     c = sin8_t(c / 2 + t);
     byte b = sin8_t(c + t/8);
-    SEGMENT.setPixelColor(i, CHSV(b + hue, 255, 255));
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(b + hue, false, true, 3));
   }
 
   return FRAMETIME;
 } // mode_FlowStripe()
-static const char _data_FX_MODE_FLOWSTRIPE[] PROGMEM = "Flow Stripe@Hue speed,Effect speed;;";
+static const char _data_FX_MODE_FLOWSTRIPE[] PROGMEM = "Flow Stripe@Hue speed,Effect speed;;!;pal=11";
 
 
 #ifndef WLED_DISABLE_2D


### PR DESCRIPTION
the effect has been broken ever since it was added in 0.14. 
The original effect used a float, the ported effect does not. The division therefore always results in 0 or 1 and thus not displaying any color spectrum but the same color for all LEDs. 
Multiplying before the division fixes the effect back to its original intended look.

Added palette support while I was at it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved color calculation in the "Flow Stripe" effect for smoother and more accurate visual transitions.

- **Enhancements**
	- Updated the "Flow Stripe" effect to use palette-based colors, allowing for richer and more customizable color schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->