### PR TITLE
Added on/off event to trigger auto save event

### DIFF
--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.cpp
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.cpp
@@ -57,6 +57,7 @@ class AutoSaveUsermod : public Usermod {
     uint8_t knownEffectIntensity = 0;
     uint8_t knownMode = 0;
     uint8_t knownPalette = 0;
+    boolean knownPowerState = false; // power state of the strip, used to detect changes
 
     #ifdef USERMOD_FOUR_LINE_DISPLAY
     FourLineDisplayUsermod* display;
@@ -110,6 +111,7 @@ class AutoSaveUsermod : public Usermod {
       knownEffectIntensity = effectIntensity;
       knownMode = strip.getMainSegment().mode;
       knownPalette = strip.getMainSegment().palette;
+      knownPowerState = offMode;
     }
 
     // gets called every time WiFi is (re-)connected. Initialize own network
@@ -141,6 +143,9 @@ class AutoSaveUsermod : public Usermod {
         autoSaveAfter = wouldAutoSaveAfter;
       } else if (knownPalette != currentPalette) {
         knownPalette = currentPalette;
+        autoSaveAfter = wouldAutoSaveAfter;
+      } else if (knownPowerState != offMode) {
+        knownPowerState = offMode;
         autoSaveAfter = wouldAutoSaveAfter;
       }
 


### PR DESCRIPTION
This change will add on/off event of LED to trigger auto save event, which will be applied after power restore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Auto-save now also triggers when the power state of the LED strip changes, ensuring settings are saved automatically after turning the strip on or off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->