### PR TITLE
Maint: convert IR library to Arduino-IRremote

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -139,7 +139,7 @@ upload_speed = 115200
 lib_compat_mode = strict
 lib_deps =
     fastled/FastLED @ 3.6.0
-    IRremoteESP8266 @ 2.8.2
+    https://github.com/Arduino-IRremote/Arduino-IRremote.git#v4.4.2
     makuna/NeoPixelBus @ 2.8.3
     #https://github.com/makuna/NeoPixelBus.git#CoreShaderBeta
     https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.0
@@ -227,7 +227,7 @@ lib_deps_compat =
   ESPAsyncUDP
   ESP8266PWM
   fastled/FastLED @ 3.6.0
-  IRremoteESP8266 @ 2.8.2
+  https://github.com/Arduino-IRremote/Arduino-IRremote.git#v4.4.2
   makuna/NeoPixelBus @ 2.7.9
   https://github.com/blazoncek/QuickESPNow.git#optional-debug
   https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.0

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -751,19 +751,19 @@ void handleIR()
     irCheckedTime = currentTime;
     if (IrReceiver.decode()) {
       auto &results = IrReceiver.decodedIRData;
-      uint32_t code = esp8266Value((uint32_t)results.decodedRawData);
-      if (results.numberOfBits != 0 && serialCanTX && results.protocol != UNKNOWN ) { // only print results if anything is received ( != 0 )
+      uint32_t value = esp8266Value((uint32_t)results.decodedRawData);
+      if (results.numberOfBits != 0 && serialCanTX) { // only print results if anything is received ( != 0 )
           Serial.printf_P(PSTR("  Protocol Received: %s\n"), decodeTypeToStr(results.protocol));
           Serial.printf_P(PSTR("  Raw Data: %d\n"), results.decodedRawData);
           Serial.printf_P(PSTR("  Address: 0x%X\n"), results.address);
           Serial.printf_P(PSTR("  Command: 0x%lX\n"), (unsigned long)results.command);
           Serial.printf_P(PSTR("  Num Bits: %d\n"), results.numberOfBits);
-          Serial.printf_P(PSTR("  Code: 0x%06lX\n"), (unsigned long)code);
+          Serial.printf_P(PSTR("  Code: 0x%06lX\n"), (unsigned long)value);
 
           Serial.println();
           Serial.println(F("========================="));
       }
-      decodeIR(code);
+      decodeIR(value);
       IrReceiver.resume();
     }
   }

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -734,8 +734,14 @@ void handleIR()
 
       // we need to reverse the bits for NEC, SAMSUNG and SONY remotes to not break backwards compatability
       uint32_t value;
-      if (results.protocol == NEC || results.protocol == SAMSUNG || results.protocol == SONY) {
-        value = bitreverse32Bit(results.decodedRawData);
+      if (results.protocol == NEC || results.protocol == SAMSUNG || results.protocol == SONY)
+      { 
+        if ( results.decodedRawData == 0 ) {
+          value = 0xFFFFFFFF; // if we get a 0, we assume it is a repeat code
+        }
+        else { 
+          value = bitreverse32Bit(results.decodedRawData);
+        }
       }
       else {
         value = results.decodedRawData;

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -751,22 +751,19 @@ void handleIR()
     irCheckedTime = currentTime;
     if (IrReceiver.decode()) {
       auto &results = IrReceiver.decodedIRData;
-      if (results.numberOfBits > 0) {
-        if (serialCanTX && results.protocol != UNKNOWN ) { // only print results if anything is received ( != 0 )
-            Serial.printf_P(PSTR("  Protocol Received: %s\n"), decodeTypeToStr(results.protocol));
-            Serial.printf_P(PSTR("  Raw Data: %d\n"), results.decodedRawData);
-            Serial.printf_P(PSTR("  Address: 0x%X\n"), results.address);
-            Serial.printf_P(PSTR("  Command: 0x%lX\n"), (unsigned long)results.command);
-            Serial.printf_P(PSTR("  Num Bits: %d\n"), results.numberOfBits);
+      uint32_t code = esp8266Value((uint32_t)results.decodedRawData);
+      if (results.numberOfBits != 0 && serialCanTX && results.protocol != UNKNOWN ) { // only print results if anything is received ( != 0 )
+          Serial.printf_P(PSTR("  Protocol Received: %s\n"), decodeTypeToStr(results.protocol));
+          Serial.printf_P(PSTR("  Raw Data: %d\n"), results.decodedRawData);
+          Serial.printf_P(PSTR("  Address: 0x%X\n"), results.address);
+          Serial.printf_P(PSTR("  Command: 0x%lX\n"), (unsigned long)results.command);
+          Serial.printf_P(PSTR("  Num Bits: %d\n"), results.numberOfBits);
+          Serial.printf_P(PSTR("  Code: 0x%06lX\n"), (unsigned long)code);
 
-            Serial.println();
-            Serial.println(F("========================="));
-        }
-
-        uint32_t code = esp8266Value((uint32_t)results.decodedRawData);
-        Serial.printf_P(PSTR("  Code: 0x%06lX\n"), (unsigned long)code);
-        decodeIR(code);
+          Serial.println();
+          Serial.println(F("========================="));
       }
+      decodeIR(code);
       IrReceiver.resume();
     }
   }

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -709,7 +709,8 @@ void deInitIR()
 }
 
 // to make it easy to tell what's incoming when we're debugging
-const char* decodeTypeToStr(uint8_t type) {
+const char* decodeTypeToStr(uint8_t type) 
+{
   switch (type) {
     case LG :       return "LG";
     case NEC:       return "NEC";
@@ -722,7 +723,8 @@ const char* decodeTypeToStr(uint8_t type) {
 }
 
 // reverse the bit-order of a single byte
-static uint8_t reverse8(uint8_t b) {
+static uint8_t reverse8(uint8_t b) 
+{
   b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
   b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
   b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
@@ -730,7 +732,8 @@ static uint8_t reverse8(uint8_t b) {
 }
 
 // mimic the old ESP8266 results.value so we don't have to rebuild them
-static uint32_t esp8266Value(uint32_t raw) {
+static uint32_t esp8266Value(uint32_t raw) 
+{
   // shift off the low “address” byte
   uint32_t w = raw >> 8;   // e.g. 0x00A35CFF
   uint8_t b2 = reverse8((w >> 16) & 0xFF);

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -722,29 +722,6 @@ const char* decodeTypeToStr(uint8_t type)
   }
 }
 
-// reverse the bit-order of a single byte
-static uint8_t reverse8(uint8_t b) 
-{
-  b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
-  b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
-  b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
-  return b;
-}
-
-// mimic the old ESP8266 results.value so we don't have to rebuild them
-static uint32_t esp8266Value(uint32_t raw) 
-{
-  // shift off the low “address” byte
-  uint32_t w = raw >> 8;   // e.g. 0x00A35CFF
-  uint8_t b2 = reverse8((w >> 16) & 0xFF);
-  uint8_t b1 = reverse8((w >>  8) & 0xFF);
-  uint8_t b0 = reverse8((w      ) & 0xFF);
-  return (((uint32_t)b0 << 16)
-        | ((uint32_t)b1 <<  8)
-        | ((uint32_t)b2      ))
-        & 0x00FFFFFF;
-}
-
 void handleIR()
 {
   unsigned long currentTime = millis();
@@ -754,18 +731,29 @@ void handleIR()
     irCheckedTime = currentTime;
     if (IrReceiver.decode()) {
       auto &results = IrReceiver.decodedIRData;
-      uint32_t value = esp8266Value((uint32_t)results.decodedRawData);
-      if (results.numberOfBits != 0 && serialCanTX) { // only print results if anything is received ( != 0 )
-          Serial.printf_P(PSTR("  Protocol Received: %s\n"), decodeTypeToStr(results.protocol));
-          Serial.printf_P(PSTR("  Raw Data: %d\n"), results.decodedRawData);
-          Serial.printf_P(PSTR("  Address: 0x%X\n"), results.address);
-          Serial.printf_P(PSTR("  Command: 0x%lX\n"), (unsigned long)results.command);
-          Serial.printf_P(PSTR("  Num Bits: %d\n"), results.numberOfBits);
-          Serial.printf_P(PSTR("  Code: 0x%06lX\n"), (unsigned long)value);
 
-          Serial.println();
-          Serial.println(F("========================="));
+      // we need to reverse the bits for NEC, SAMSUNG and SONY remotes to not break backwards compatability
+      uint32_t value;
+      if (results.protocol == NEC || results.protocol == SAMSUNG || results.protocol == SONY) {
+        value = bitreverse32Bit(results.decodedRawData);
       }
+      else {
+        value = results.decodedRawData;
+      }
+
+      // all the returns for IR in case we need to debug a remote
+      DEBUG_PRINTF_P(PSTR("IR Protocol Received: %s\n"), decodeTypeToStr(results.protocol));
+      DEBUG_PRINTF_P(PSTR("  Raw Data: %d\n"), results.decodedRawData);
+      DEBUG_PRINTF_P(PSTR("  Address: 0x%X\n"), results.address);
+      DEBUG_PRINTF_P(PSTR("  Command: 0x%lX\n"), (unsigned long)results.command);
+      DEBUG_PRINTF_P(PSTR("  Num Bits: %d\n"), results.numberOfBits);
+      DEBUG_PRINTF_P(PSTR("  Value: 0x%0lX\n"), (unsigned long)value);
+
+      #ifndef WLED_DEBUG
+        if (results.numberOfBits != 0 && serialCanTX) { // only print results if anything is received ( != 0 )
+            Serial.printf_P(PSTR("  Protocol Received: %s, Value: 0x%0lX\n"), decodeTypeToStr(results.protocol), (unsigned long)value);
+        }
+      #endif
       decodeIR(value);
       IrReceiver.resume();
     }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -230,12 +230,6 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
   Comment out this error message to build regardless.
 #endif
 
-#ifndef WLED_DISABLE_INFRARED
-  #include <IRremoteESP8266.h>
-  #include <IRrecv.h>
-  #include <IRutils.h>
-#endif
-
 //Filesystem to use for preset and config files. SPIFFS or LittleFS on ESP8266, SPIFFS only on ESP32 (now using LITTLEFS port by lorol)
 #ifdef ESP8266
   #define WLED_FS LittleFS


### PR DESCRIPTION
IRremoteESP8266 appears abandoned ( last updated July 2023 ).

It's based on Arduino-IRremote, which *IS* being maintained, and is not quite a drop in swap.

So, I swapped them. 😛 

I did have to make a choice here to either re-order all of ir_codes.h or swap the byte order for results.decodedRawData so that it could mimic results.value. I went with swapping the byte order via esp8266Value(), because changing all of ir_codes.h sounds unpleasant to review, and like it's just asking for issues.

Also added in some debugging output for the serial monitor so it's easier to see what's going on.

License changes from GNU GPL -> MIT, so that seems fine here.

This is part of a bigger change that allows WLED to work with MagiQuest wands from Great Wolf Lodge. The wands aren't working with the old IRremoteESP8266 library, but they do with this one! I'm just breaking the changes up for ease of processing. (https://github.com/Graimalkin/WLED/pull/2)

## Testing:
Tested with an ESP32 dev board, TSOP4838 IR sensor, and generic LED light strip. Also grabbed one of the white 44 key IR remotes from Amazon -- https://www.amazon.com/dp/B0982BVCSD

Colors changed, brightness goes up and down, can swap to presets.

*I'd recommend trying on a few more hardware stacks if you have it.*

![image](https://github.com/user-attachments/assets/90daed8b-05d9-4a2d-93a1-84df399d5d32)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated infrared remote control support to use a newer IR library, improving compatibility and reliability.
  - Enhanced debug output for IR remote decoding.
  - Maintained compatibility with previous IR code values.

- **Chores**
  - Updated dependency for the IR remote library to a newer version from a different source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->