### PR TITLE
WLED_DISABLE_2D does not compile

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -763,7 +763,7 @@ class Segment {
     inline void drawCharacter(unsigned char chr, int16_t x, int16_t y, uint8_t w, uint8_t h, CRGB c, CRGB c2 = CRGB::Black, int8_t rotate = 0) const { drawCharacter(chr, x, y, w, h, RGBW32(c.r,c.g,c.b,0), RGBW32(c2.r,c2.g,c2.b,0), rotate); } // automatic inline
     inline void fill_solid(CRGB c) const { fill(RGBW32(c.r,c.g,c.b,0)); }
   #else
-    inline constexpr bool is2D() const                                            { return false; }
+    inline bool is2D() const                                                      { return false; }
     inline void setPixelColorXY(int x, int y, uint32_t c) const                   { setPixelColor(x, c); }
     inline void setPixelColorXY(unsigned x, unsigned y, uint32_t c) const         { setPixelColor(int(x), c); }
     inline void setPixelColorXY(int x, int y, byte r, byte g, byte b, byte w = 0) const { setPixelColor(x, RGBW32(r,g,b,w)); }


### PR DESCRIPTION
the compilation fails with tons of errors if you try to compile using WLED_DISABLE_2D
- **message**: _enclosing class of constexpr non-static member function 'bool Segment::is2D() const' is not a literal type_
- **LineNumber**: _766_

to reproduce the issue you can _Run Build Task_ with this example environment:
```
[env:test_2D-on]
extends = env:esp32dev
build_flags = ${env:esp32dev.build_flags}
  -D WLED_MAX_BUTTONS=1
  -D BTNPIN=-1
```
it will compile, while running this:
```
[env:test_2D-off]
extends = env:esp32dev
build_flags = ${env:esp32dev.build_flags}
  -D WLED_MAX_BUTTONS=1
  -D BTNPIN=-1
  -D WLED_DISABLE_2D
```
fails.