### PR TITLE
Bugfix: convert cctBlend value back to "%" for UI

### DIFF
--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -190,8 +190,8 @@ class Bus {
     static inline uint8_t  getGlobalAWMode()          { return _gAWM; }
     static inline void     setCCT(int16_t cct)        { _cct = cct; }
     static inline uint8_t  getCCTBlend()              { return _cctBlend; }
-    static inline void     setCCTBlend(uint8_t b) {
-      _cctBlend = (std::min((int)b,100) * 127) / 100;
+    static inline void     setCCTBlend(uint8_t b) {        // input is 0-100
+      _cctBlend = (std::min((int)b,100) * 127 + 50) / 100; // +50 for rounding, b=100% -> 127
       //compile-time limiter for hardware that can't power both white channels at max
       #ifdef WLED_MAX_CCT_BLEND
         if (_cctBlend > WLED_MAX_CCT_BLEND) _cctBlend = WLED_MAX_CCT_BLEND;

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -288,7 +288,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormCheckbox(settingsScript,PSTR("CCT"),strip.correctWB);
     printSetFormCheckbox(settingsScript,PSTR("IC"),cctICused);
     printSetFormCheckbox(settingsScript,PSTR("CR"),strip.cctFromRgb);
-    printSetFormValue(settingsScript,PSTR("CB"),Bus::getCCTBlend());
+    printSetFormValue(settingsScript,PSTR("CB"),(Bus::getCCTBlend() * 100 + 64) / 127); // 100% = 127, +64 for rounding
     printSetFormValue(settingsScript,PSTR("FR"),strip.getTargetFps());
     printSetFormValue(settingsScript,PSTR("AW"),Bus::getGlobalAWMode());
     printSetFormCheckbox(settingsScript,PSTR("PR"),BusManager::hasParallelOutput());  // get it from bus manager not global variable


### PR DESCRIPTION
This fixes a bug where when using CCT blending the value changes each time the LED config page is saved.
Reason is:
input is in %
value is stored as 0-127
value is not converted back to % when sending it to the UI, increasing the value each time.

- added proper rounding when storing the value
- added conversion to % when sending it to UI

I checked the conversion is done correctly for all 100 input values.