### PR TITLE
Fix validation after removing a usermod

### DIFF
--- a/pio-scripts/validate_modules.py
+++ b/pio-scripts/validate_modules.py
@@ -53,9 +53,10 @@ def validate_map_file(source, target, env):
         secho(f"ERROR: Map file not found: {map_file_path}", fg="red", err=True)
         Exit(1)
 
-    # Identify the WLED module source directories
-    module_lib_builders = [builder for builder in env.GetLibBuilders() if is_wled_module(env, builder)]
+    # Identify the WLED module builders, set by load_usermods.py
+    module_lib_builders = env['WLED_MODULES']
 
+    # Filter/warn if an incompatible usermod was requested
     if env.GetProjectOption("custom_usermods","") == "*":
         # All usermods build; filter non-platform-OK modules
         module_lib_builders = [builder for builder in module_lib_builders if env.IsCompatibleLibBuilder(builder)]

--- a/pio-scripts/validate_modules.py
+++ b/pio-scripts/validate_modules.py
@@ -56,19 +56,6 @@ def validate_map_file(source, target, env):
     # Identify the WLED module builders, set by load_usermods.py
     module_lib_builders = env['WLED_MODULES']
 
-    # Filter/warn if an incompatible usermod was requested
-    if env.GetProjectOption("custom_usermods","") == "*":
-        # All usermods build; filter non-platform-OK modules
-        module_lib_builders = [builder for builder in module_lib_builders if env.IsCompatibleLibBuilder(builder)]
-    else:
-        incompatible_builders = [builder for builder in module_lib_builders if not env.IsCompatibleLibBuilder(builder)]
-        if incompatible_builders:
-            secho(
-                f"ERROR: Modules {[b.name for b in incompatible_builders]} are not compatible with this platform!",
-                fg="red",
-                err=True)
-            Exit(1)
-
     # Extract the values we care about
     modules = {Path(builder.build_dir).name: builder.name for builder in module_lib_builders}
     secho(f"INFO: {len(modules)} libraries linked as WLED optional/user modules")


### PR DESCRIPTION
When removing a usermod from an existing environment, PlatformIO does not clean up the `.pio/libdeps` folder.   This confused the `validate_modules.py` script: to avoid replicating the usermod mapping logic, it assumed every usermod library it could see in the build ought to be included in the build.   So when a usermod was removed, it would incorrectly fault claiming it wasn't included.

Instead, have `load_usermods.py` leave the actual expected module list in the environment for `validate_modules.py` to pick up.

As a side effect, this disables the ability to check for modules that aren't compatible with the current platform, as they're filtered out before the list capture in `load_usermods.py` is run.  (This is the normal behaviour of `lib_deps`, for better or for worse.)  I've just removed the nonfunctional code, as out-of-tree modules are expected to be put in `lib_deps`, so they'll have that behaviour anyways; we might as well just be consistent about it.  We can add that feature back later if it turns out to be worthwhile.