### PR TITLE
fixed compiler warnings

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7856,10 +7856,11 @@ uint16_t mode_particlefireworks(void) {
   // check each rocket's state and emit particles according to its state: moving up = emit exhaust, at top = explode; falling down = standby time
   uint32_t emitparticles, frequency, baseangle, hueincrement; // number of particles to emit for each rocket's state
   // variables for circular explosions
-  [[maybe_unused]] int32_t speed, currentspeed, speedvariation, percircle;
+  [[maybe_unused]] int32_t speed = 2; // just init to min value
+  [[maybe_unused]] int32_t currentspeed, percircle;
   int32_t counter = 0;
-  [[maybe_unused]] uint16_t angle;
-  [[maybe_unused]] unsigned angleincrement;
+  [[maybe_unused]] uint16_t angle = 0; // just init to zero
+  [[maybe_unused]] unsigned angleincrement = 2730; // minimum 15°
   bool circularexplosion = false;
 
   // emit particles for each rocket


### PR DESCRIPTION
fixed compiler warnings for uninitialized vars
fixed compiler warnings for unused variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability of the Particle Fireworks effect by ensuring internal variables are properly initialized, reducing the risk of unexpected behavior.

- **Refactor**
  - Enhanced configuration handling to only process EEPROM and interface settings when relevant features (such as MQTT or HueSync) are enabled, optimizing performance and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->