### PR TITLE
Adding DSP FFT and integer math to AR

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -534,6 +534,7 @@ platform = ${esp32c3.platform}
 framework = arduino
 board = esp32-c3-devkitm-1
 board_build.partitions = ${esp32.default_partitions}
+custom_usermods = audioreactive
 build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-C3\"
   -D WLED_WATCHDOG_TIMEOUT=0
   -DLOLIN_WIFI_FIX ; seems to work much better with this

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -24,7 +24,64 @@
  * ....
  */
 
-#define FFT_PREFER_EXACT_PEAKS  // use different FFT windowing -> results in "sharper" peaks and less "leaking" into other frequencies
+#define FFT_PREFER_EXACT_PEAKS  // use Blackman-Harris FFT windowing instead of Flat Top -> results in "sharper" peaks and less "leaking" into other frequencies (credits to @softhack)
+
+/*
+ * Note on FFT variants:
+ * - ArduinoFFT: uses floating point calculations, very slow on S2 and C3 (no FPU)
+ * - ESP-IDF DSP library:
+     - faster but uses ~13k of extra flash on ESP32 and S3
+ *   - uses integer math on S2 and C3: slightly less accurate but over 10x faster than ArduinoFFT and uses less flash
+     - not available in IDF < 4.4
+ * - ArduinoFFT is used by default on ESP32 and S3
+ * - ESP-IDF DSP FFT with integer math is used by default on S2 and C3
+ * - defines:
+ *   - UM_AUDIOREACTIVE_USE_ARDUINO_FFT: use ArduinoFFT library for FFT (for S2 and C3)
+ *   - UM_AUDIOREACTIVE_USE_ESPDSP_FFT:  use ESP-IDF DSP for FFT (for ESP32 and S3 on IDF >= 4.4)
+*/
+
+//#define UM_AUDIOREACTIVE_USE_ESPDSP_FFT
+//#define UM_AUDIOREACTIVE_USE_INTEGER_FFT // use integer FFT if using ESP-IDF DSP library, always used on S2 and C3 (UM_AUDIOREACTIVE_USE_ARDUINO_FFT takes priority)
+#if !defined(UM_AUDIOREACTIVE_USE_ESPDSP_FFT) || ((defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)) && !defined(UM_AUDIOREACTIVE_USE_ARDUINO_FFT))
+#define UM_AUDIOREACTIVE_USE_ARDUINO_FFT // use ArduinoFFT library for FFT instead of ESP-IDF DSP library by default, except ESP32-S2 and ESP32-C3
+#endif
+
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
+#define UM_AUDIOREACTIVE_USE_ARDUINO_FFT // DSP FFT library is not available in ESP-IDF < 4.4
+#endif
+
+#ifdef UM_AUDIOREACTIVE_USE_ARDUINO_FFT
+#include <arduinoFFT.h> // ArduinoFFT library for FFT and window functions
+#else
+#include "dsps_fft2r.h" // ESP-IDF DSP library for FFT and window functions
+#ifdef FFT_PREFER_EXACT_PEAKS
+#include "dsps_wind_blackman_harris.h"
+#else
+#include "dsps_wind_flat_top.h"
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#define UM_AUDIOREACTIVE_USE_INTEGER_FFT // always use integer FFT on ESP32-S2 and ESP32-C3
+#endif
+#endif
+
+// These are the input and output vectors.  Input vectors receive computed results from FFT.
+#if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
+static float* valFFT = nullptr;
+#else
+static int16_t* valFFT = nullptr;
+#endif
+#ifdef UM_AUDIOREACTIVE_USE_ARDUINO_FFT
+static float* vImag = nullptr; // imaginary part of FFT results
+#endif
+
+// pre-computed window function
+#if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
+__attribute__((aligned(16))) float* windowFFT;
+#else
+__attribute__((aligned(16))) int16_t* windowFFT;
+#endif
+
 
 #if !defined(FFTTASK_PRIORITY)
 #define FFTTASK_PRIORITY 1 // standard: looptask prio
@@ -155,7 +212,7 @@ static bool useBandPassFilter = false;                    // if true, enables a 
 // some prototypes, to ensure consistent interfaces
 static float fftAddAvg(int from, int to);   // average of several FFT result bins
 void FFTcode(void * parameter);      // audio processing task: read samples, run FFT, fill GEQ channels from FFT results
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
 static void runMicFilter(uint16_t numSamples, float *sampleBuffer);          // pre-filtering of raw samples (band-pass)
 #else
 static void runMicFilter(uint16_t numSamples, int16_t *sampleBuffer);
@@ -202,22 +259,6 @@ constexpr uint16_t samplesFFT_2 = 256;          // meaningfull part of FFT resul
 #endif
 #define LOG_256  5.54517744f                            // log(256)
 
-// These are the input and output vectors.  Input vectors receive computed results from FFT.
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
-static float* valFFT = nullptr;
-#else
-static int16_t* valFFT = nullptr;
-#endif
-
-
-// pre-computed window function
-#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
-__attribute__((aligned(16))) int16_t* windowFFT;
-#else
-__attribute__((aligned(16))) float* windowFFT;
-#endif
-
-
 // Create FFT object
 // lib_deps += https://github.com/kosme/arduinoFFT#develop @ 1.9.2
 // these options actually cause slow-downs on all esp32 processors, don't use them.
@@ -226,19 +267,11 @@ __attribute__((aligned(16))) float* windowFFT;
 // Below options are forcing ArduinoFFT to use sqrtf() instead of sqrt()
 // #define sqrt_internal sqrtf          // see https://github.com/kosme/arduinoFFT/pull/83 - since v2.0.0 this must be done in build_flags
 
-// ESP-IDF DSP library for FFT and window functions
-#include "dsps_fft2r.h"
-#ifdef FFT_PREFER_EXACT_PEAKS
-#include "dsps_wind_blackman_harris.h"
-#else
-#include "dsps_wind_flat_top.h"
-#endif
-
 // Helper functions
 
 // compute average of several FFT result bins
 static float fftAddAvg(int from, int to) {
-  #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+  #if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
   float result = 0.0f;
   for (int i = from; i <= to; i++) {
     result += valFFT[i];
@@ -259,22 +292,31 @@ static float fftAddAvg(int from, int to) {
 void FFTcode(void * parameter)
 {
   DEBUGSR_PRINT("FFT started on core: "); DEBUGSR_PRINTLN(xPortGetCoreID());
-
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#ifdef UM_AUDIOREACTIVE_USE_ARDUINO_FFT
+  // allocate FFT buffers on first call
+  if (valFFT == nullptr) valFFT = (float*) calloc(sizeof(float), samplesFFT);
+  if (vImag == nullptr) vImag = (float*) calloc(sizeof(float), samplesFFT);
+  if ((valFFT == nullptr) || (vImag == nullptr)) {
+    // something went wrong
+    if (valFFT) free(valFFT); valFFT = nullptr;
+    if (vImag) free(vImag); vImag = nullptr;
+    return;
+  }
+  // Create FFT object with weighing factor storage
+  ArduinoFFT<float> FFT = ArduinoFFT<float>(valFFT, vImag, samplesFFT, SAMPLE_RATE, true);
+#elif !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
   // allocate and initialize FFT buffers on first call
   if (valFFT == nullptr) {
     float* raw_buffer = (float*)heap_caps_malloc((2 * samplesFFT * sizeof(float)) + 16, MALLOC_CAP_8BIT);
     if ((raw_buffer == nullptr)) return; // something went wrong
     valFFT = (float*)(((uintptr_t)raw_buffer + 15) & ~15);  // SIMD requires aligned memory to 16-byte boundary. note in IDF5 there is MALLOC_CAP_SIMD available
   }
-
   // create window
   if (windowFFT == nullptr) {
     float* raw_buffer = (float*)heap_caps_malloc((samplesFFT * sizeof(float)) + 16, MALLOC_CAP_8BIT);
     if ((raw_buffer == nullptr)) return; // something went wrong
     windowFFT = (float*)(((uintptr_t)raw_buffer + 15) & ~15);  // SIMD requires aligned memory to 16-byte boundary
   }
-
   if (dsps_fft2r_init_fc32(NULL, samplesFFT) != ESP_OK) return; // initialize FFT tables
   // create window function for FFT
 #ifdef FFT_PREFER_EXACT_PEAKS
@@ -283,7 +325,7 @@ void FFTcode(void * parameter)
   dsps_wind_flat_top_f32(windowFFT, samplesFFT);
 #endif
 #else
-// allocate and initialize FFT buffers on first call
+  // allocate and initialize integer FFT buffers on first call
   if (valFFT == nullptr) valFFT = (int16_t*) calloc(sizeof(int16_t), samplesFFT * 2);
   if ((valFFT == nullptr)) return; // something went wrong
   // create window
@@ -304,7 +346,6 @@ void FFTcode(void * parameter)
   }
   free(windowFloat); // free temporary buffer
 #endif
-
 
   // see https://www.freertos.org/vtaskdelayuntil.html
   const TickType_t xFrequency = FFT_MIN_CYCLE * portTICK_PERIOD_MS;  
@@ -343,7 +384,7 @@ void FFTcode(void * parameter)
     if (useBandPassFilter) runMicFilter(samplesFFT, valFFT);
 
     // find highest sample in the batch
-    #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+    #if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
     float maxSample = 0.0f;                         // max sample from FFT batch
     for (int i=0; i < samplesFFT; i++) {
 	    // pick our  our current mic sample - we take the max value from all samples that go into FFT
@@ -368,8 +409,19 @@ void FFTcode(void * parameter)
     if (sampleAvg > 0.25f) { // noise gate open means that FFT results will be used. Don't run FFT if results are not needed.
 #endif
 
-      // run FFT (takes ~x ms on ESP32, ~x ms on ESP32-S2, , ~x ms on ESP32-C3)
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#ifdef UM_AUDIOREACTIVE_USE_ARDUINO_FFT
+      // run Arduino FFT (takes 3-5ms on ESP32, ~12ms on ESP32-S2, ~20ms on ESP32-C3)
+      FFT.dcRemoval();                                            // remove DC offset
+      FFT.windowing( FFTWindow::Flat_top, FFTDirection::Forward); // Weigh data using "Flat Top" function - better amplitude accuracy
+      //FFT.windowing(FFTWindow::Blackman_Harris, FFTDirection::Forward);  // Weigh data using "Blackman- Harris" window - sharp peaks due to excellent sideband rejection
+      FFT.compute( FFTDirection::Forward );                       // Compute FFT
+      FFT.complexToMagnitude();                                   // Compute magnitudes
+      valFFT[0] = 0;   // The remaining DC offset on the signal produces a strong spike on position 0 that should be eliminated to avoid issues.
+
+      FFT.majorPeak(&FFT_MajorPeak, &FFT_Magnitude);                // let the effects know which freq was most dominant
+      FFT_MajorPeak = constrain(FFT_MajorPeak, 1.0f, 11025.0f);   // restrict value to range expected by effects
+#elif !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
+      // run run float DSP FFT (takes ~x ms on ESP32, ~x ms on ESP32-S2, , ~x ms on ESP32-C3) TODO: test and fill in these values
       // remove DC offset
       float sum = 0;
       for (int i = 0; i < samplesFFT; i++) sum += valFFT[i];
@@ -383,22 +435,28 @@ void FFTcode(void * parameter)
         valFFT[i * 2 + 1] = 0.0; // set imaginary part to zero
       }
 #ifdef CONFIG_IDF_TARGET_ESP32S3
-      dsps_fft2r_fc32_aes3(valFFT, samplesFFT); // ESP32 S3 optimized version of FFT (requires 16bit aligned buffer!)
+      dsps_fft2r_fc32_aes3(valFFT, samplesFFT); // ESP32 S3 optimized version of FFT
 #elif defined(CONFIG_IDF_TARGET_ESP32)
       dsps_fft2r_fc32_ae32(valFFT, samplesFFT); // ESP32 optimized version of FFT
 #else
-      dsps_fft2r_fc32_ansi(valFFT, samplesFFT); // perform FFT
+      dsps_fft2r_fc32_ansi(valFFT, samplesFFT); // perform FFT using ANSI C implementation
 #endif
       dsps_bit_rev_fc32(valFFT, samplesFFT);    // bit reverse
-
-      // convert to magnitude
+      // convert to magnitude & find FFT_MajorPeak and FFT_Magnitude
+      FFT_MajorPeak = 0;
+      FFT_Magnitude = 0;
       for (int i = 1; i < samplesFFT_2; i++) {  // skip [0] as it is DC offset
         float real_part = valFFT[i * 2];
         float imag_part = valFFT[i * 2 + 1];
         valFFT[i] = sqrtf(real_part * real_part + imag_part * imag_part);
+        if (valFFT[i] > FFT_Magnitude) {
+          FFT_Magnitude = valFFT[i];
+          FFT_MajorPeak = i*(SAMPLE_RATE/samplesFFT);
+        }
         valFFT[i] = valFFT[i] / 16.0f;          // Reduce magnitude. Want end result to be scaled linear and ~4096 max.
       }
 #else
+      // run integer DSP FFT (takes ~x ms on ESP32, ~x ms on ESP32-S2, , ~1.5 ms on ESP32-C3) TODO: test and fill in these values
       // remove DC offset
       int32_t sum = 0;
       for (int i = 0; i < samplesFFT; i++) sum += valFFT[i];
@@ -411,24 +469,30 @@ void FFTcode(void * parameter)
         valFFT[i * 2] = windowed_sample;
         valFFT[i * 2 + 1] = 0; // set imaginary part to zero
       }
-
       dsps_fft2r_sc16_ansi(valFFT, samplesFFT); // perform FFT on complex value pairs (Re,Im)
       dsps_bit_rev_sc16(valFFT, samplesFFT);    // bit reverse i.e. "unshuffle" the results
 
       // convert to magnitude, FFT returns interleaved complex values [Re,Im,Re,Im,...]
+      int FFT_MajorPeak_int = 0;
+      int FFT_Magnitude_int = 0;
       for (int i = 1; i < samplesFFT_2; i++) { // skip [0], it is DC offset
         int32_t real_part = valFFT[i * 2];
         int32_t imag_part = valFFT[i * 2 + 1];
         valFFT[i] = sqrt32_bw(real_part * real_part + imag_part * imag_part); // note: this should never overflow as Re and Im form a vector of maximum length 32767
+        if (valFFT[i] > FFT_Magnitude_int) {
+          FFT_Magnitude_int = valFFT[i];
+          FFT_MajorPeak_int = ((i * SAMPLE_RATE)/samplesFFT);
+        }
+        // note: scaling is done when converting to float in fftAddAvg(), so we don't scale here
       }
+      FFT_MajorPeak = FFT_MajorPeak_int;
+      FFT_Magnitude = FFT_Magnitude_int;
+
 #endif
       valFFT[0] = 0;   // The remaining DC offset on the signal produces a strong spike on position 0 that should be eliminated to avoid issues.
 #if defined(WLED_DEBUG) || defined(SR_DEBUG)
       haveDoneFFT = true;
 #endif
-
-    //TODO calculate FFT_MajorPeak and FFT_Magnitude, that code was removed from here
-
     } else { // noise gate closed - only clear results as FFT was skipped. MIC samples are still valid when we do this.
       memset(valFFT, 0, samplesFFT * sizeof(float)); // only lower half of buffer contains FFT results, so only clear that part
       FFT_MajorPeak = 1;
@@ -527,7 +591,7 @@ void FFTcode(void * parameter)
 // Pre / Postprocessing  //
 ///////////////////////////
 
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
 static void runMicFilter(uint16_t numSamples, float *sampleBuffer)          // pre-filtering of raw samples (band-pass)
 {
   // low frequency cutoff parameter - see https://dsp.stackexchange.com/questions/40462/exponential-moving-average-cut-off-frequency

--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -332,22 +332,6 @@ class I2SSource : public AudioSource {
           return;
         }
 
-        //debug function:  Generate sine wave
-      for (int i = 0; i < num_samples; i++) {
-          float frequencies[] = {250.0, 1200.0, 2600.0, 5500.0}; // 4 test frequencies
-          float amplitudes[] = {10000, 8000, 6000, 4000};
-          float time = (float)i / 22000;
-          float sample = 0.0;
-          //float scale = 990848.0;
-          sample =  sin(2.0 * PI * frequencies[0] * time)* amplitudes[0] *65536; 
-          sample +=  sin(2.0 * PI * frequencies[1] * time)* amplitudes[1]*65536; 
-          sample +=  sin(2.0 * PI * frequencies[2] * time)* amplitudes[2]*65536; 
-          sample +=  sin(2.0 * PI * frequencies[3] * time)* amplitudes[3]*65536; 
-          newSamples[i] = (int32_t)(sample); //(float)(millis()<<7));  // scale up
-        }
-      //!!!remove
-
-
         // Store samples in sample buffer
 #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
         float* _buffer = static_cast<float*>(buffer);
@@ -371,6 +355,7 @@ class I2SSource : public AudioSource {
 #else
   #ifdef I2S_SAMPLE_DOWNSCALE_TO_16BIT
           // note on sample scaling: scaling is only used for inputs with master clock and those are better suited for ESP32 or S3
+          // execution speed is critical on single core MCUs
           //int32_t currSample = newSamples[i] >> FIXEDSHIFT;   // shift to avoid overlow in multiplication
           //currSample = (currSample * intSampleScale) >> 16;   // scale samples, shift down to 16bit
           int16_t currSample = newSamples[i] >> 16;           // no sample scaling, just shift down to 16bit (not scaling saves ~0.4ms on C3)

--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -331,8 +331,20 @@ class I2SSource : public AudioSource {
           DEBUGSR_PRINTF("Failed to get enough samples: wanted: %d read: %d\n", sizeof(newSamples), bytes_read);
           return;
         }
+/*
+  //debug function:  Generate sine wave 
+ for (int i = 0; i < num_samples; i++) {
+    float time = (float)i / 22000;
+    float sample = 0.0;
+    sample =  sin(2.0 * PI * 1000 * time); // 1000 Hz sine wav
+    sample +=  sin(2.0 * PI * 250 * time); // 1000 Hz sine wav
+    newSamples[i] = (int32_t)(sample * 990848.0); //(float)(millis()<<7));  // scale up
+  }
+*/ //!!!remove
 
-        // Store samples in sample buffer and update DC offset
+
+
+        // Store samples in sample buffer
 #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
         int16_t* _buffer = static_cast<int16_t*>(buffer); // use integer samples on ESP32-S2 and ESP32-C3
         constexpr int32_t FIXEDSHIFT = 8; // shift by 8 bits for fixed point math (no loss at 24bit input sample resolution)

--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -334,12 +334,16 @@ class I2SSource : public AudioSource {
 
         //debug function:  Generate sine wave
       for (int i = 0; i < num_samples; i++) {
+          float frequencies[] = {250.0, 1200.0, 2600.0, 5500.0}; // 4 test frequencies
+          float amplitudes[] = {10000, 8000, 6000, 4000};
           float time = (float)i / 22000;
           float sample = 0.0;
-          sample =  sin(2.0 * PI * 1000 * time); // 1kHz sine wave
-          sample +=  sin(2.0 * PI * 250 * time); // 250 Hz sine wave
-          sample +=  sin(2.0 * PI * 4000 * time); // 4kHz sine wave
-          newSamples[i] = (int32_t)(sample * 990848.0); //(float)(millis()<<7));  // scale up
+          //float scale = 990848.0;
+          sample =  sin(2.0 * PI * frequencies[0] * time)* amplitudes[0] *65536; 
+          sample +=  sin(2.0 * PI * frequencies[1] * time)* amplitudes[1]*65536; 
+          sample +=  sin(2.0 * PI * frequencies[2] * time)* amplitudes[2]*65536; 
+          sample +=  sin(2.0 * PI * frequencies[3] * time)* amplitudes[3]*65536; 
+          newSamples[i] = (int32_t)(sample); //(float)(millis()<<7));  // scale up
         }
       //!!!remove
 

--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -22,7 +22,7 @@
 
 // see https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/chip-series-comparison.html#related-documents
 // and https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/i2s.html#overview-of-all-modes
-#if defined(CONFIG_IDF_TARGET_ESP32C2) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2) || defined(ESP8266) || defined(ESP8265)
+#if defined(CONFIG_IDF_TARGET_ESP32C2) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2) || defined(ESP8266) || defined(ESP8265)
   // there are two things in these MCUs that could lead to problems with audio processing:
   // * no floating point hardware (FPU) support - FFT uses float calculations. If done in software, a strong slow-down can be expected (between 8x and 20x)
   // * single core, so FFT task might slow down other things like LED updates
@@ -333,7 +333,7 @@ class I2SSource : public AudioSource {
         }
 
         // Store samples in sample buffer
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
         float* _buffer = static_cast<float*>(buffer);
 #else
         int16_t* _buffer = static_cast<int16_t*>(buffer); // use integer samples on ESP32-S2 and ESP32-C3
@@ -344,7 +344,7 @@ class I2SSource : public AudioSource {
         for (int i = 0; i < num_samples; i++) {
           newSamples[i] = postProcessSample(newSamples[i]);  // perform postprocessing (needed for ADC samples)
 
-#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
   #ifdef I2S_SAMPLE_DOWNSCALE_TO_16BIT
           float currSample = (float) newSamples[i] / 65536.0f;      // 32bit input -> 16bit; keeping lower 16bits as decimal places
   #else


### PR DESCRIPTION
- Added ESP DSP FFT option for all ESP32 variants
  - ESP32 and S3 still use ArduinoFFT by default because DSP FFT uses ~13k extra flash
  - S2 and C3 use DSP FFT with integer math by default
- Added integer math for handling sample filter and FFT bin post-processing
- `useBandPassFilter` applied to all mic inputs: tested with INMP441 and sine-tones from speaker -> reduces aliasing to base bands and highest frequency bands and comes at minimal processing cost

On the C3 the DSP FFT saves 3k of flash but uses 6k of heap, probably for FFT internal buffers.
On the S2 the DSP FFT uses 2.2k extra flash, did not check heap but most likely the same as on C3

Sampling time and FFT time on S2 and C3 are now just barely higher than on ESP32 or S3. Using the DSP FFT on ESP32 or S3 uses the highly optimized versions (roughly 2x as fast as Arduino FFT but at a high extra flash cost and probably also heap).

Some speed test results:

**ESP32** Speed test with 512 samples:
Arduino FFT (float): 0.9ms
DSP FFT (float): 0.49ms
DSP FFT (16bit integer): 1.4ms
 
ESP32 **S3** Speed test with 512 samples:
Arduino FFT (float): 0.90ms
DSP FFT (float): 0.51ms  (0.68ms if using ANSI C version)
DSP FFT (16bit integer): 1.1ms
 
ESP32 **S2** Speed test with 512 samples:
Arduino FFT (float): 8.5ms
DSP FFT (float): 7.2ms
DSP FFT (16bit integer): 1.3ms
 
ESP32 **C3** Speed test with 512 samples:
Arduino FFT (float): 22.0ms
DSP FFT (float): 19.1ms
DSP FFT (16bit integer): 1.4ms

@softhack007 I moved the scaling of float version (/16.0) up into the FFT code as I did not see any reason it is not done there. Any issue with that?

I tested all versions with a simulated set of sine waves on all platforms, ArduinoFFT and DSP FFT produce identical results, integer version is of course slightly less accurate but produces very comparable results. I also compared ArduinoFFT and integer FFT side-by-side using PS GEQ 1D: while the ArduinoFFT sometimes picks up on low-volume sounds, the integer FFT is much more responsive thanks to faster processing. In general, all variants behave almost the same.