### PR TITLE
Fix incorrect usermod name: LD2410 -> LD2410_v2

### DIFF
--- a/usermods/LD2410_v2/readme.md
+++ b/usermods/LD2410_v2/readme.md
@@ -18,7 +18,7 @@ To enable, compile with `LD2140` in `custom_usermods` (e.g. in `platformio_overr
 ```ini
 [env:usermod_USERMOD_LD2410_esp32dev]
 extends = env:esp32dev
-custom_usermods = ${env:esp32dev.custom_usermods} LD2140
+custom_usermods = ${env:esp32dev.custom_usermods} LD2140_v2
 ```
 
 ### Configuration Options


### PR DESCRIPTION
Compiling the WLED firmware with the `LD2410` usermod fails because there is no module with that name in the `usermods` directory.

The correct usermod directory is `LD2410_v2`, so the usermod name must match that exactly in the build configuration.

This fix updates the example or documentation (depending on what you're editing) to reflect the correct usermod name.

Tested with: `platformio_override.ini` using:
```ini
custom_usermods = ${env:esp32dev.custom_usermods} LD2410_v2
