### PR TITLE
Add new effect for a single EQ bar with peak marker and decay

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7272,19 +7272,17 @@ uint16_t mode_single_eqbar(void) {
 
   // Draw the main bar (but not peak pixel)
   for (int i = 0; i < barHeight; i++) {
-    if (i < barHeight) {
-      // Draw the main bar according to the palette. Don't draw the top pixel, that's drawn by the peak handling.
-      SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
-    }
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
   }
 
   if (peakDecay == 0 && barHeight > 0){
-    // No peak pixel if decay is set to zero, just draw the bar.
+    // No peak pixel if decay is set to zero, just draw the peak pixel of the bar.
     SEGMENT.setPixelColor(barHeight, SEGMENT.color_from_palette(barHeight, true, PALETTE_SOLID_WRAP, 0));
   } else {
-    // Peak decay, set pixel and handle decay. Clear pixels over peak (otherwise they would fadewith value from speed slider)
+    // Decrement prevBarHeight according to peakDecay
     if (*prevBarHeight > 0 && (SEGENV.call % (peakDecay > 1 ? peakDecay : 1)) == 0) (*prevBarHeight)--;
 
+    // Set peak pixel and clear pixels over peak (otherwise they would fadewith value from speed slider)
     if (*prevBarHeight > 0) {
       SEGMENT.setPixelColor(*prevBarHeight, SEGCOLOR(2));
     }
@@ -7295,7 +7293,7 @@ uint16_t mode_single_eqbar(void) {
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_SINGLE_EQBAR[] PROGMEM = "Single EQ Bar@Fade speed,Ripple decay,Frequency bin;!,,Peaks;!;!;1vf;c1=0,c2=8,si=0";
+static const char _data_FX_MODE_SINGLE_EQBAR[] PROGMEM = "Single EQ Bar@Fade speed,Peak decay,Frequency bin;!,,Peaks;!;!;1vf;sx=128,ix=170,c1=128,si=0";
 
 /////////////////////////
 //  ** 2D Funky plank  //

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7260,6 +7260,7 @@ uint16_t mode_single_eqbar(void) {
   um_data_t *um_data = getAudioData();
   uint8_t *fftResult = (uint8_t*)um_data->u_data[2];
   if (!fftResult) return mode_static();
+  bool is2d = (strip.isMatrix || SEGMENT.is2D());
 
   // User controls. Speed is referenced directly instead of creating a new varible.
   uint8_t freqBin = map(SEGMENT.custom1, 0, 255, 0, 15); // 0-15 (or up to available bins)
@@ -7280,7 +7281,7 @@ uint16_t mode_single_eqbar(void) {
 
   // Draw the main bar (but not peak pixel)
   for (int i = 0; i < barHeight; i++) {
-    if (strip.isMatrix || SEGMENT.is2D()){
+    if (is2d){
       // If we are in a matrix or 2D segment, draw the bar vertically
       for (int j = 0; j < SEG_W; j++) {
         SEGMENT.setPixelColorXY(j, i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
@@ -7294,7 +7295,7 @@ uint16_t mode_single_eqbar(void) {
   if (peakDecay == 0){
     // No peak pixel if decay is set to zero, just draw the peak pixel of the bar.
     if (barHeight > 0) {
-      if (strip.isMatrix || SEGMENT.is2D()) {
+      if (is2d) {
         for (int j = 0; j < SEG_W; j++) {
           SEGMENT.setPixelColorXY(j, barHeight, SEGMENT.color_from_palette(barHeight, true, PALETTE_SOLID_WRAP, 0));
         } 
@@ -7309,7 +7310,7 @@ uint16_t mode_single_eqbar(void) {
     // Set peak pixel and clear pixels over peak (otherwise they would fadewith value from speed slider)
     if (*prevBarHeight > 0) {
 
-      if (strip.isMatrix || SEGMENT.is2D()) {
+      if (is2d) {
         for (int j = 0; j < SEG_W; j++) {
           SEGMENT.setPixelColorXY(j, *prevBarHeight, SEGCOLOR(2));
         }
@@ -7319,7 +7320,7 @@ uint16_t mode_single_eqbar(void) {
     }
     if (*prevBarHeight < SEGLEN) {
 
-      if (strip.isMatrix || SEGMENT.is2D()) {
+      if (is2d) {
         for (int j = 0; j < SEG_W; j++) {
           SEGMENT.setPixelColorXY(j, *prevBarHeight + 1, BLACK); // clear next pixel immediately.
         }

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7275,9 +7275,11 @@ uint16_t mode_single_eqbar(void) {
     SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
   }
 
-  if (peakDecay == 0 && barHeight > 0){
+  if (peakDecay == 0){
     // No peak pixel if decay is set to zero, just draw the peak pixel of the bar.
-    SEGMENT.setPixelColor(barHeight, SEGMENT.color_from_palette(barHeight, true, PALETTE_SOLID_WRAP, 0));
+    if (barHeight > 0) {
+      SEGMENT.setPixelColor(barHeight, SEGMENT.color_from_palette(barHeight, true, PALETTE_SOLID_WRAP, 0));
+    }
   } else {
     // Decrement prevBarHeight according to peakDecay
     if (*prevBarHeight > 0 && (SEGENV.call % (peakDecay > 1 ? peakDecay : 1)) == 0) (*prevBarHeight)--;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7263,8 +7263,11 @@ uint16_t mode_single_eqbar(void) {
 
   // User controls. Speed is referenced directly instead of creating a new varible.
   uint8_t freqBin = map(SEGMENT.custom1, 0, 255, 0, 15); // 0-15 (or up to available bins)
-  uint8_t peakDecay = (SEGMENT.intensity == 0) ? 0 : map(255 - SEGMENT.intensity, 1, 255, 1, 32); // Grab the intensity value for peak decay speed. Invert for ease of use.
-
+  uint8_t peakDecay = SEGMENT.intensity;
+  if (peakDecay > 0){
+    // Grab the intensity value for peak decay speed, bound it between 1 and 32, invert for ease of use.
+    peakDecay = map(255 - SEGMENT.intensity, 1, 255, 1, 32);
+  }
   int barHeight = map(fftResult[freqBin], 0, 255, 0, SEGLEN); // Grab new bar height
   if (barHeight > *prevBarHeight) *prevBarHeight = barHeight; // Update the previous bar height if the new height is greater
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -374,6 +374,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_PS1DSPRINGY            216
 #define FX_MODE_PARTICLEGALAXY         217
 #define MODE_COUNT                     218
+#define FX_MODE_SINGLE_EQBAR           219
 
 
 #define BLEND_STYLE_FADE            0x00  // universal


### PR DESCRIPTION
Currently there is not anything that can duplicate the geq-style functionality for a selected frequency bin on a single segment - so I wrote one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new audio-reactive LED effect that displays a single equalizer bar, responsive to a user-selected frequency bin.
  * The effect supports both 1D and 2D LED setups, with customizable peak decay and bar fade speeds.
  * Peak levels are visually highlighted for enhanced audio visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->