### PR TITLE
Adding center bin selection to 2D GEQ

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7258,11 +7258,10 @@ uint16_t mode_2DGEQ(void) { // By Will Tatam. Code reduction by Ewoud Wijma.
 
   for (int x=0; x < cols; x++) {
     int band = map(x, 0, cols, 0, NUM_BANDS);
-    //if (NUM_BANDS < 16) band = map(band, 0, NUM_BANDS - 1, 0, 15); // always use full range. comment out this line to get the previous behaviour.
     if (NUM_BANDS < 16) {
         int startBin = constrain(CENTER_BIN - NUM_BANDS/2, 0, 15 - NUM_BANDS + 1);
         if(NUM_BANDS <= 1)
-          band = CENTER_BIN; // mapping does not work for 1 band
+          band = CENTER_BIN; // map() does not work for single band
         else
           band = map(band, 0, NUM_BANDS - 1, startBin, startBin + NUM_BANDS - 1);
     }

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7270,6 +7270,7 @@ uint16_t mode_2DGEQ(void) { // By Will Tatam. Code reduction by Ewoud Wijma.
     unsigned colorIndex = band * 17;
     int barHeight  = map(fftResult[band], 0, 255, 0, rows); // do not subtract -1 from rows here
     if (barHeight > previousBarHeight[x]) previousBarHeight[x] = barHeight; //drive the peak up
+
     uint32_t ledColor = BLACK;
     for (int y=0; y < barHeight; y++) {
       if (SEGMENT.check1) //color_vertical / color bars toggle


### PR DESCRIPTION
setting custom3 to 0 gives the "old" behaviour, this is the default for new presets. Existing presets will have the custom3 slider at the center, changing presets that do not use the full width.