### PR TITLE
(0.15.x backport) bus_wrapper: Use parallel I2S first when enabled

### DIFF
--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -469,12 +469,20 @@ class PolyBus {
   }
 
   static void* create(uint8_t busType, uint8_t* pins, uint16_t len, uint8_t channel) {
-    #if defined(ARDUINO_ARCH_ESP32) && !(defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3))
     // NOTE: "channel" is only used on ESP32 (and its variants) for RMT channel allocation
+
+    #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+    if (_useParallelI2S && (channel >= 8)) {
+        // Parallel I2S channels are to be used first, so subtract 8 to get the RMT channel number
+        channel -= 8;
+    }
+    #endif
+
+    #if defined(ARDUINO_ARCH_ESP32) && !(defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3))
     // since 0.15.0-b3 I2S1 is favoured for classic ESP32 and moved to position 0 (channel 0) so we need to subtract 1 for correct RMT allocation
     if (!_useParallelI2S && channel > 0) channel--; // accommodate I2S1 which is used as 1st bus on classic ESP32
-    // if user selected parallel I2S, RMT is used 1st (8 channels) followed by parallel I2S (8 channels)
     #endif
+
     void* busPtr = nullptr;
     switch (busType) {
       case I_NONE: break;
@@ -1428,7 +1436,7 @@ class PolyBus {
       // ESP32-S2 only has 4 RMT channels
       if (_useParallelI2S) {
         if (num > 11) return I_NONE;
-        if (num > 3) offset = 1;    // use x8 parallel I2S0 channels (use last to allow Audioreactive)
+        if (num < 8) offset = 1;    // use x8 parallel I2S0 channels (use last to allow Audioreactive)
       } else {
         if (num > 4) return I_NONE;
         if (num > 3) offset = 1;  // only one I2S0 (use last to allow Audioreactive)
@@ -1441,7 +1449,7 @@ class PolyBus {
       // On ESP32-S3 only the first 4 RMT channels are usable for transmitting
       if (_useParallelI2S) {
         if (num > 11) return I_NONE;
-        if (num > 3) offset = 1;    // use x8 parallel I2S LCD channels
+        if (num < 8) offset = 1;    // use x8 parallel I2S LCD channels
       } else {
         if (num > 3) return I_NONE; // do not use single I2S (as it is not supported)
       }
@@ -1449,7 +1457,7 @@ class PolyBus {
       // standard ESP32 has 8 RMT and x1/x8 I2S1 channels
       if (_useParallelI2S) {
         if (num > 15) return I_NONE;
-        if (num > 7) offset = 1;  // 8 RMT followed by 8 I2S
+        if (num < 8) offset = 1;  // 8 RMT followed by 8 I2S
       } else {
         if (num > 9) return I_NONE;
         if (num == 0) offset = 1; // prefer I2S1 for 1st bus (less flickering but more RAM needed)

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1436,7 +1436,8 @@ class PolyBus {
       // ESP32-S2 only has 4 RMT channels
       if (_useParallelI2S) {
         if (num > 11) return I_NONE;
-        if (num < 8) offset = 1;    // use x8 parallel I2S0 channels (use last to allow Audioreactive)
+        if (num < 8) offset = 1;    // use x8 parallel I2S0 channels followed by RMT
+                                    // Note: conflicts with AudioReactive if enabled
       } else {
         if (num > 4) return I_NONE;
         if (num > 3) offset = 1;  // only one I2S0 (use last to allow Audioreactive)
@@ -1449,7 +1450,7 @@ class PolyBus {
       // On ESP32-S3 only the first 4 RMT channels are usable for transmitting
       if (_useParallelI2S) {
         if (num > 11) return I_NONE;
-        if (num < 8) offset = 1;    // use x8 parallel I2S LCD channels
+        if (num < 8) offset = 1;    // use x8 parallel I2S LCD channels, followed by RMT
       } else {
         if (num > 3) return I_NONE; // do not use single I2S (as it is not supported)
       }
@@ -1457,7 +1458,7 @@ class PolyBus {
       // standard ESP32 has 8 RMT and x1/x8 I2S1 channels
       if (_useParallelI2S) {
         if (num > 15) return I_NONE;
-        if (num < 8) offset = 1;  // 8 RMT followed by 8 I2S
+        if (num < 8) offset = 1;  // 8 I2S followed by 8 RMT
       } else {
         if (num > 9) return I_NONE;
         if (num == 0) offset = 1; // prefer I2S1 for 1st bus (less flickering but more RAM needed)


### PR DESCRIPTION
Backport of #4762 to 0.15.x.