### PR TITLE
Fix for #4643 - Missing MQTT updates

### DIFF
--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -347,8 +347,13 @@ void initServer()
     if (verboseResponse) {
       if (!isConfig) {
         lastInterfaceUpdate = millis(); // prevent WS update until cooldown
-        interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
-        serveJson(request); return; //if JSON contains "v"
+        interfaceUpdateCallMode = CALL_MODE_WS_SEND; // override call mode & schedule WS update
+        #ifndef WLED_DISABLE_MQTT
+        // publish state to MQTT as requested in wled#4643 even if only WS response selected
+        publishMqtt();
+        #endif
+        serveJson(request);
+        return; //if JSON contains "v"
       } else {
         configNeedsWrite = true; //Save new settings to FS
       }

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -59,6 +59,10 @@ void wsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTyp
 
         if (!interfaceUpdateCallMode) { // individual client response only needed if no WS broadcast soon
           if (verboseResponse) {
+            #ifndef WLED_DISABLE_MQTT
+            // publish state to MQTT as requested in wled#4643 even if only WS response selected
+            publishMqtt();
+            #endif
             sendDataWs(client);
           } else {
             // we have to send something back otherwise WS connection closes


### PR DESCRIPTION
Fixes #4643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MQTT state publication now occurs when verbose responses are requested via the JSON HTTP endpoint or WebSocket, provided MQTT support is enabled.

* **Bug Fixes**
  * Ensured MQTT updates are sent in sync with verbose API responses for improved state consistency across integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->