### PR TITLE
Add Lightweight Preset Scheduling

### DIFF
--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -178,6 +178,11 @@
 		Countdown Goal:<br>
 		Date:&nbsp;<nowrap>20<input name="CY" class="xs" type="number" min="0" max="99" required>-<input name="CI" class="xs" type="number" min="1" max="12" required>-<input name="CD" class="xs" type="number" min="1" max="31" required></nowrap><br>
 		Time:&nbsp;<nowrap><input name="CH" class="xs" type="number" min="0" max="23" required>:<input name="CM" class="xs" type="number" min="0" max="59" required>:<input name="CS" class="xs" type="number" min="0" max="59" required></nowrap><br>
+		<h3>Upload Schedule JSON</h3>
+		<input type="file" name="scheduleFile" id="scheduleFile" accept=".json">
+		<input type="button" value="Upload" onclick="uploadFile(d.Sf.scheduleFile, '/schedule.json');">
+		<br>
+		<a class="btn lnk" id="bckschedule" href="/schedule.json" download="schedule">Backup schedule</a><br>
 		<h3>Macro presets</h3>
 		<b>Macros have moved!</b><br>
 		<i>Presets now also can be used as macros to save both JSON and HTTP API commands.<br>

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -96,11 +96,31 @@ bool loadSchedule() {
     for (JsonObject e : doc.as<JsonArray>()) {
         if (numScheduleEvents >= MAX_SCHEDULE_EVENTS) break;
 
+        // Extract and validate JSON fields before assignment
+        int sm = e["sm"].as<int>();
+        int sd = e["sd"].as<int>();
+        int em = e["em"].as<int>();
+        int ed = e["ed"].as<int>();
+        int r  = e["r"].as<int>();
+        int h  = e["h"].as<int>();
+        int m  = e["m"].as<int>();
+        int p  = e["p"].as<int>();
+        
+        // Validate ranges: months 1–12, days 1–31, hours 0–23, minutes 0–59,
+        // repeat mask 0–127, preset ID 1–250
+        if (sm < 1 || sm > 12 || em < 1 || em > 12 ||
+            sd < 1 || sd > 31 || ed < 1 || ed > 31 ||
+            h  < 0 || h  > 23 || m  < 0 || m  > 59 ||
+            r  < 0 || r  > 127|| p  < 1 || p  > 250) {
+            DEBUG_PRINTF_P(PSTR("[Schedule] Invalid values in event %u, skipping\n"), numScheduleEvents);
+            continue;
+        }
+
         scheduleEvents[numScheduleEvents++] = {
-            (uint8_t)e["sm"].as<int>(), (uint8_t)e["sd"].as<int>(), // start month, day
-            (uint8_t)e["em"].as<int>(), (uint8_t)e["ed"].as<int>(), // end month, day
-            (uint8_t)e["r"].as<int>(),  (uint8_t)e["h"].as<int>(),  // repeat mask, hour
-            (uint8_t)e["m"].as<int>(),  (uint8_t)e["p"].as<int>()   // minute, preset
+            (uint8_t)sm, (uint8_t)sd,
+            (uint8_t)em, (uint8_t)ed,
+            (uint8_t)r,  (uint8_t)h,
+            (uint8_t)m,  (uint8_t)p
         };
     }
 

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -1,0 +1,105 @@
+// schedule.cpp
+
+//TODO: make schedule.json trigger loadshedule(); on upload istead of just once a min (line 50)
+
+#include "schedule.h"
+#include <WLED.h>
+#include <time.h>
+
+#define SCHEDULE_FILE "/schedule.json"
+
+ScheduleEvent scheduleEvents[MAX_SCHEDULE_EVENTS];
+uint8_t numScheduleEvents = 0;
+
+bool isTodayInRange(uint8_t sm, uint8_t sd, uint8_t em, uint8_t ed, uint8_t cm, uint8_t cd)
+{
+    if (sm < em || (sm == em && sd <= ed))
+    {
+        return (cm > sm || (cm == sm && cd >= sd)) &&
+               (cm < em || (cm == em && cd <= ed));
+    }
+    else
+    {
+        return (cm > sm || (cm == sm && cd >= sd)) ||
+               (cm < em || (cm == em && cd <= ed));
+    }
+}
+
+
+// Checks the schedule and applies any events that match the current time and date.
+
+void checkSchedule() {
+    static int lastMinute = -1;
+  
+    time_t now = localTime;
+    if (now < 100000) return;
+  
+    struct tm* timeinfo = localtime(&now);
+    int thisMinute = timeinfo->tm_min + timeinfo->tm_hour * 60;
+  
+    if (thisMinute == lastMinute) return;
+    lastMinute = thisMinute;
+  
+
+    uint8_t cm = timeinfo->tm_mon + 1; // months since Jan (0-11)
+    uint8_t cd = timeinfo->tm_mday;
+    uint8_t wday = timeinfo->tm_wday; // days since Sunday (0-6)
+    uint8_t hr = timeinfo->tm_hour;
+    uint8_t min = timeinfo->tm_min;
+
+    loadSchedule();
+    DEBUG_PRINTF_P(PSTR("[Schedule] Checking schedule at %02u:%02u\n"), hr, min);
+
+    for (uint8_t i = 0; i < numScheduleEvents; i++)
+    {
+        const ScheduleEvent &e = scheduleEvents[i];
+        if (e.hour != hr || e.minute != min)
+            continue;
+
+        bool match = false;
+        if (e.repeatMask && ((e.repeatMask >> wday) & 0x01))
+            match = true;
+        if (e.startMonth)
+        {
+            if (isTodayInRange(e.startMonth, e.startDay, e.endMonth, e.endDay, cm, cd))
+                match = true;
+        }
+
+        if (match)
+            applyPreset(e.presetId);
+            DEBUG_PRINTF_P(PSTR("[Schedule] Applying preset %u at %02u:%02u\n"), e.presetId, hr, min);
+            DEBUG_PRINTF_P(PSTR("[Schedule] Checked event %u: match=%d\n"), i, match);
+    }
+}
+
+void loadSchedule()
+{
+    if (!WLED_FS.exists(SCHEDULE_FILE))
+        return;
+    File file = WLED_FS.open(SCHEDULE_FILE, "r");
+    if (!file)
+        return;
+
+    DynamicJsonDocument doc(4096);
+    if (deserializeJson(doc, file))
+    {
+        file.close();
+        return;
+    }
+    file.close();
+
+    numScheduleEvents = 0;
+    for (JsonObject e : doc.as<JsonArray>())
+    {
+        if (numScheduleEvents >= MAX_SCHEDULE_EVENTS)
+            break;
+        scheduleEvents[numScheduleEvents++] = {
+            (uint8_t)e["sm"], (uint8_t)e["sd"], // start month, day
+            (uint8_t)e["em"], (uint8_t)e["ed"], // end month, day
+            (uint8_t)e["r"], (uint8_t)e["h"], // repeat mask, hour
+            (uint8_t)e["m"], (uint8_t)e["p"]}; // minute, preset
+    }
+    DEBUG_PRINTF_P(PSTR("[Schedule] Loaded %u schedule entries from schedule.json\n"), numScheduleEvents);
+
+}
+

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -1,6 +1,5 @@
 // schedule.cpp
 
-//TODO: make schedule.json trigger loadshedule(); on upload istead of just once a min (line 50)
 
 #include "schedule.h"
 #include <WLED.h>
@@ -47,7 +46,6 @@ void checkSchedule() {
     uint8_t hr = timeinfo->tm_hour;
     uint8_t min = timeinfo->tm_min;
 
-    loadSchedule();
     DEBUG_PRINTF_P(PSTR("[Schedule] Checking schedule at %02u:%02u\n"), hr, min);
 
     for (uint8_t i = 0; i < numScheduleEvents; i++)

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -68,7 +68,6 @@ void checkSchedule() {
             applyPreset(e.presetId);
             DEBUG_PRINTF_P(PSTR("[Schedule] Applying preset %u at %02u:%02u\n"), e.presetId, hr, min);
         }
-        DEBUG_PRINTF_P(PSTR("[Schedule] Checked event %u: match=%d\n"), i, match);   
     }
 }
 

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -66,9 +66,11 @@ void checkSchedule() {
         }
 
         if (match)
+        {
             applyPreset(e.presetId);
             DEBUG_PRINTF_P(PSTR("[Schedule] Applying preset %u at %02u:%02u\n"), e.presetId, hr, min);
-            DEBUG_PRINTF_P(PSTR("[Schedule] Checked event %u: match=%d\n"), i, match);
+        }
+        DEBUG_PRINTF_P(PSTR("[Schedule] Checked event %u: match=%d\n"), i, match);   
     }
 }
 

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -94,10 +94,10 @@ void loadSchedule()
         if (numScheduleEvents >= MAX_SCHEDULE_EVENTS)
             break;
         scheduleEvents[numScheduleEvents++] = {
-            (uint8_t)e["sm"], (uint8_t)e["sd"], // start month, day
-            (uint8_t)e["em"], (uint8_t)e["ed"], // end month, day
-            (uint8_t)e["r"], (uint8_t)e["h"], // repeat mask, hour
-            (uint8_t)e["m"], (uint8_t)e["p"]}; // minute, preset
+            (uint8_t)e["sm"].as<int>(), (uint8_t)e["sd"].as<int>(), // start month, day
+            (uint8_t)e["em"].as<int>(), (uint8_t)e["ed"].as<int>(), // end month, day
+            (uint8_t)e["r"].as<int>(), (uint8_t)e["h"].as<int>(), // repeat mask, hour
+            (uint8_t)e["m"].as<int>(), (uint8_t)e["p"].as<int>()}; // minute, preset
     }
     DEBUG_PRINTF_P(PSTR("[Schedule] Loaded %u schedule entries from schedule.json\n"), numScheduleEvents);
 

--- a/wled00/schedule.h
+++ b/wled00/schedule.h
@@ -16,5 +16,5 @@ struct ScheduleEvent {
   uint8_t presetId;
 };
 
-void loadSchedule();
+bool loadSchedule();
 void checkSchedule();

--- a/wled00/schedule.h
+++ b/wled00/schedule.h
@@ -1,0 +1,20 @@
+// schedule.h
+#pragma once
+
+#include <stdint.h>
+
+#define MAX_SCHEDULE_EVENTS 32
+
+struct ScheduleEvent {
+  uint8_t startMonth;
+  uint8_t startDay;
+  uint8_t endMonth;
+  uint8_t endDay;
+  uint8_t repeatMask;
+  uint8_t hour;
+  uint8_t minute;
+  uint8_t presetId;
+};
+
+void loadSchedule();
+void checkSchedule();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -54,6 +54,7 @@ void WLED::loop()
 #endif
 
   handleTime();
+  checkSchedule();
   #ifndef WLED_DISABLE_INFRARED
   handleIR();        // 2nd call to function needed for ESP32 to return valid results -- should be good for ESP8266, too
   #endif
@@ -526,6 +527,8 @@ void WLED::setup()
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 1); //enable brownout detector
   #endif
+
+  loadSchedule();
 }
 
 void WLED::beginStrip()

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -66,6 +66,8 @@
 
 #include <cstddef>
 #include <vector>
+#include "schedule.h"
+
 
 // Library inclusions.
 #include <Arduino.h>

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -202,7 +202,13 @@ static void handleUpload(AsyncWebServerRequest *request, const String& filename,
 
   // Write chunk
   if (len && request->_tempFile) {
-    request->_tempFile.write(data, len);
+    size_t written = request->_tempFile.write(data, len);
+    if (written != len) {
+      DEBUG_PRINTLN(F("File write error during upload"));
+      request->_tempFile.close();
+      request->_tempFile = File(); // invalidate file handle
+      // Consider sending error response early
+    }
   }
 
   // Finalize upload


### PR DESCRIPTION
_Disclaimer: I have basically no experience with doing this kind of thing, I'm just good a hooking ai up to stuff, so I was able to teach myself enough to get by._ 

This PR introduces a lightweight scheduling system that applies WLED presets automatically based on time and date. The goal is to enable users to automate WLED behavior without needing external automations or integrations.

**Purpose**
This allows users to:

- Run presets on specific dates (e.g. holidays, birthdays)
- Trigger effects at set times weekly (e.g. every Friday at 6 PM)
- Build repeatable, time-based lighting behaviors with zero network dependencies

It works purely offline, and is simple enough to be used by less technical users via a JSON file (as in people not running home assistant or similar).

**How it works**

- A schedule.json can be uploaded via /settings/time
~~- The schedule system loads this file on startup and... every minute (TODO: Make the load schedule only trigger on upload and startup [schedule.cpp loadSchedule() function])~~ Now only loads on startup and upload [37a536a]
- Each schedule entry contains a time, an optional date range, and/or a weekly repeat bitmask.
- When the current time matches an entry, the configured preset is applied.
- The checkSchedule() gets called in the wled.cpp loop() and if it was triggered less than a minute ago doesn't (fully) trigger. (TODO: Implement anti-duplicate trigger better [schedule.cpp lines 32-41])

**JSON Formating**

- sm, sd, em, ed: Start/end month & day (date range)
- r: Weekly repeat bitmask (bit 0 = Sunday, bit 6 = Saturday)
- h, m: Hour and minute to trigger
- p: Preset ID to apply
```JSON
[
  {
    "sm": 7,
    "sd": 4,
    "em": 7,
    "ed": 4,
    "r": 0,
    "h": 20,
    "m": 30,
    "p": 5
  },
  {
    "sm": 0,
    "sd": 0,
    "em": 0,
    "ed": 0,
    "r": 34,
    "h": 7,
    "m": 15,
    "p": 2
  }
]
 ```

Explanation:
First entry: Runs preset 5 on July 4th at 20:30 every year.

Second entry: Runs preset 2 every Monday and Friday at 07:15.
(Repeat bitmask 34 = 0b100010 = Monday and Friday)

**Testing**

- Verified that schedule.json loads properly at startup
- Confirmed scheduled presets trigger correctly and only once per minute
- Logged matched events using DEBUG_PRINTF when WLED_DEBUG is defined
- Tested both date-based and repeat-based schedules
- Confirmed working on a nodemcu v2 _ESP8266_, d1mini _ESP8266_, and a d1mini _ESP32_.

**Limitations / Future Work**

- [as mentioned above]: (TODO: Implement anti-duplicate trigger better [schedule.cpp lines 32-41]), ~~and (TODO: Make the load schedule only trigger on upload and boot [schedule.cpp loadSchedule() function])~~
- No UI for schedule editing yet (future enhancement possible)
- Does not support second-level precision (minute-level only, by design)
- Only presets can be triggered (no other macro types or HTTP actions)

**Notes for maintainers**

- No core WLED behavior was changed
- All new code is modular and self-contained in schedule.cpp/.h
- Can be made into a build flag to be included or not.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a scheduling system that allows users to automate preset activations based on custom schedules defined in a JSON file.
  * Added an interface on the time settings page for uploading and downloading schedule JSON files, enabling easy backup and management of schedules.

* **Enhancements**
  * Automated schedule checks and preset activations now run seamlessly in the background.
  * Schedule uploads are now handled safely with temporary files to ensure reliable updates and immediate application of new schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->