### PR TITLE
Lightweight Scheduling System Proposal (Feedback Requested)

### DIFF
--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -178,6 +178,11 @@
 		Countdown Goal:<br>
 		Date:&nbsp;<nowrap>20<input name="CY" class="xs" type="number" min="0" max="99" required>-<input name="CI" class="xs" type="number" min="1" max="12" required>-<input name="CD" class="xs" type="number" min="1" max="31" required></nowrap><br>
 		Time:&nbsp;<nowrap><input name="CH" class="xs" type="number" min="0" max="23" required>:<input name="CM" class="xs" type="number" min="0" max="59" required>:<input name="CS" class="xs" type="number" min="0" max="59" required></nowrap><br>
+		<h3>Upload Schedule JSON</h3>
+		<input type="file" name="scheduleFile" id="scheduleFile" accept=".json">
+		<input type="button" value="Upload" onclick="uploadFile(d.Sf.scheduleFile, '/schedule.json');">
+		<br>
+		<a class="btn lnk" id="bckschedule" href="/schedule.json" download="schedule">Backup schedule</a><br>
 		<h3>Macro presets</h3>
 		<b>Macros have moved!</b><br>
 		<i>Presets now also can be used as macros to save both JSON and HTTP API commands.<br>

--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -8,6 +8,8 @@
 	<script>
 	var el=false;
 	var ms=["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+	var maxTimePresets = 16; // Maximum number of time-controlled presets
+	var currentPresetCount = 3; // Current number of presets (sunrise + sunset + 1 permanent time preset)
 	function S() {
 		getLoc();
 		loadJS(getURL('/settings/s.js?p=5'), false, ()=>{BTa();}, ()=>{
@@ -27,60 +29,183 @@
 	function BTa()
 	{
 		var ih="<thead><tr><th>En.</th><th>Hour</th><th>Minute</th><th>Preset</th><th></th></tr></thead>";
-		for (i=0;i<8;i++) {
-			ih+=`<tr><td><input name="W${i}" id="W${i}" type="hidden"><input id="W${i}0" type="checkbox"></td>
-<td><input name="H${i}" class="xs" type="number" min="0" max="24"></td>
-<td><input name="N${i}" class="xs" type="number" min="0" max="59"></td>
+		// Generate sunrise preset (0)
+		ih += generatePresetRow(0, true, "Sunrise");
+		// Generate sunset preset (1)
+		ih += generatePresetRow(1, true, "Sunset");
+		// Generate one permanent time preset (2)
+		ih += generatePresetRow(2, false, null, false);
+		// Generate any additional dynamic presets (starting from 3)
+		for (i=3; i<currentPresetCount; i++) {
+			ih += generatePresetRow(i, false, null, true);
+		}
+		gId("TMT").innerHTML=ih;
+	}
+
+	function generatePresetRow(i, isSunEvent = false, sunType = null, isDynamic = false) {
+		var ih = "";
+		var hourInput = isSunEvent ? 
+			`${sunType}<input name="H${i}" value="255" type="hidden">` : 
+			`<input name="H${i}" class="xs" type="number" min="0" max="24">`;
+		
+		ih += `<tr id="preset-row-${i}"><td><input name="W${i}" id="W${i}" type="hidden"><input id="W${i}0" type="checkbox"></td>
+<td>${hourInput}</td>
+<td><input name="N${i}" class="xs" type="number" min="${isSunEvent ? '-59' : '0'}" max="59"></td>
 <td><input name="T${i}" class="s" type="number" min="0" max="250"></td>
 <td><div id="CB${i}" onclick="expand(this,${i})" class="cal">&#128197;</div></td></tr>`;
-			ih+=`<tr><td colspan=5><div id="WD${i}" style="display:none;background-color:#444;"><hr>Run on weekdays`;
-			ih+=`<table><tr><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th><th>S</th></tr><tr>`
-			for (j=1;j<8;j++) ih+=`<td><input id="W${i}${j}" type="checkbox"></td>`;
-			ih+=`</tr></table>from <select name="M${i}">`;
-			for (j=0;j<12;j++) ih+=`<option value="${j+1}">${ms[j]}</option>`;
-			ih+=`</select><input name="D${i}" class="xs" type="number" min="1" max="31"></input> to <select name="P${i}">`;
-			for (j=0;j<12;j++) ih+=`<option value="${j+1}">${ms[j]}</option>`;
-			ih+=`</select><input name="E${i}" class="xs" type="number" min="1" max="31"></input>
-		<hr></div></td></tr>`;
+		
+		ih += `<tr id="preset-detail-${i}"><td colspan=5><div id="WD${i}" style="display:none;background-color:#444;"><hr>`;
+		
+		if (!isSunEvent) {
+			ih += "Run on weekdays";
 		}
-		ih+=`<tr><td><input name="W8" id="W8" type="hidden"><input id="W80" type="checkbox"></td>
-<td>Sunrise<input name="H8" value="255" type="hidden"></td>
-<td><input name="N8" class="xs" type="number" min="-59" max="59"></td>
-<td><input name="T8" class="s" type="number" min="0" max="250"></td>
-<td><div id="CB8" onclick="expand(this,8)" class="cal">&#128197;</div></td></tr><tr><td colspan=5>`;
-		ih+=`<div id="WD8" style="display:none;background-color:#444;"><hr><table><tr><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th><th>S</th></tr><tr>`;
-		for (j=1;j<8;j++) ih+=`<td><input id="W8${j}" type="checkbox"></td>`;
-		ih+="</tr></table><hr></div></td></tr>";
-		ih+=`<tr><td><input name="W9" id="W9" type="hidden"><input id="W90" type="checkbox"></td>
-<td>Sunset<input name="H9" value="255" type="hidden"></td>
-<td><input name="N9" class="xs" type="number" min="-59" max="59"></td>
-<td><input name="T9" class="s" type="number" min="0" max="250"></td>
-<td><div id="CB9" onclick="expand(this,9)" class="cal">&#128197;</div></td></tr><tr><td colspan=5>`;
-		ih+=`<div id="WD9" style="display:none;background-color:#444;"><hr><table><tr><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th><th>S</th></tr><tr>`;
-		for (j=1;j<8;j++) ih+=`<td><input id="W9${j}" type="checkbox"></td>`;
-		ih+="</tr></table><hr></div></td></tr>";
-		gId("TMT").innerHTML=ih;
+		
+		ih += `<table><tr><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th><th>S</th></tr><tr>`;
+		for (j=1;j<8;j++) ih += `<td><input id="W${i}${j}" type="checkbox"></td>`;
+		ih += "</tr></table>";
+		
+		if (!isSunEvent) {
+			ih += `from <select name="M${i}">`;
+			for (j=0;j<12;j++) ih += `<option value="${j+1}">${ms[j]}</option>`;
+			ih += `</select><input name="D${i}" class="xs" type="number" min="1" max="31"></input> to <select name="P${i}">`;
+			for (j=0;j<12;j++) ih += `<option value="${j+1}">${ms[j]}</option>`;
+			ih += `</select><input name="E${i}" class="xs" type="number" min="1" max="31"></input>`;
+		}
+		
+		ih += "<hr></div></td></tr>";
+		return ih;
+	}
+
+	function addTimePreset() {
+		if (currentPresetCount >= maxTimePresets) {
+			alert(`Maximum of ${maxTimePresets} time presets allowed.`);
+			return;
+		}
+		
+		var table = gId("TMT");
+		var newRowHTML = generatePresetRow(currentPresetCount, false, null, true);
+		table.insertAdjacentHTML("beforeend", newRowHTML);
+		
+		currentPresetCount++;
+		updateButtonStates();
+	}
+
+	function removePreset(index) {
+		if (index < 3) {
+			alert("Cannot remove built-in presets (Sunrise, Sunset, and first time preset).");
+			return;
+		}
+		
+		// Remove the preset rows
+		var presetRow = gId(`preset-row-${index}`);
+		var detailRow = gId(`preset-detail-${index}`);
+		
+		if (presetRow) presetRow.remove();
+		if (detailRow) detailRow.remove();
+		
+		// Reindex remaining presets
+		reindexPresets();
+		currentPresetCount--;
+		updateButtonStates();
+	}
+
+	function removeLastPreset() {
+		if (currentPresetCount <= 3) {
+			alert("Cannot remove built-in presets. Only dynamic presets (3+) can be removed.");
+			return;
+		}
+		
+		// Find the highest index dynamic preset and remove it
+		var lastIndex = currentPresetCount - 1;
+		removePreset(lastIndex);
+	}
+
+	function reindexPresets() {
+		var table = gId("TMT");
+		var rows = table.querySelectorAll("tr[id^='preset-row-']");
+		var newIndex = 3;
+		
+		rows.forEach((row) => {
+			var oldIndex = row.id.split('-')[2];
+			if (parseInt(oldIndex) >= 3) {
+				updatePresetRowIndex(row, oldIndex, newIndex);
+				var detailRow = gId(`preset-detail-${oldIndex}`);
+				if (detailRow) {
+					updatePresetDetailRowIndex(detailRow, oldIndex, newIndex);
+				}
+				newIndex++;
+			}
+		});
+	}
+
+	function updatePresetRowIndex(row, oldIndex, newIndex) {
+		row.id = `preset-row-${newIndex}`;
+		row.innerHTML = row.innerHTML
+			.replace(new RegExp(`name="W${oldIndex}"`, 'g'), `name="W${newIndex}"`)
+			.replace(new RegExp(`id="W${oldIndex}`, 'g'), `id="W${newIndex}`)
+			.replace(new RegExp(`name="H${oldIndex}"`, 'g'), `name="H${newIndex}"`)
+			.replace(new RegExp(`name="N${oldIndex}"`, 'g'), `name="N${newIndex}"`)
+			.replace(new RegExp(`name="T${oldIndex}"`, 'g'), `name="T${newIndex}"`)
+			.replace(new RegExp(`id="CB${oldIndex}"`, 'g'), `id="CB${newIndex}"`)
+			.replace(new RegExp(`expand\(this,${oldIndex}\)`, 'g'), `expand(this,${newIndex})`)
+			.replace(new RegExp(`removePreset\(${oldIndex}\)`, 'g'), `removePreset(${newIndex})`);
+	}
+
+	function updatePresetDetailRowIndex(row, oldIndex, newIndex) {
+		row.id = `preset-detail-${newIndex}`;
+		row.innerHTML = row.innerHTML
+			.replace(new RegExp(`id="WD${oldIndex}"`, 'g'), `id="WD${newIndex}"`)
+			.replace(new RegExp(`id="W${oldIndex}`, 'g'), `id="W${newIndex}`)
+			.replace(new RegExp(`name="M${oldIndex}"`, 'g'), `name="M${newIndex}"`)
+			.replace(new RegExp(`name="D${oldIndex}"`, 'g'), `name="D${newIndex}"`)
+			.replace(new RegExp(`name="P${oldIndex}"`, 'g'), `name="P${newIndex}"`)
+			.replace(new RegExp(`name="E${oldIndex}"`, 'g'), `name="E${newIndex}"`);
+	}
+
+	function updateButtonStates() {
+		var addBtn = gId("addPresetBtn");
+		var removeBtn = gId("removePresetBtn");
+		
+		if (addBtn) {
+			addBtn.disabled = currentPresetCount >= maxTimePresets;
+		}
+		
+		if (removeBtn) {
+			removeBtn.disabled = currentPresetCount <= 3;
+		}
 	}
 	function FC()
 	{
-		for(i=0;i<10;i++)
+		for(i=0;i<currentPresetCount;i++)
 		{
-			let wd = gId("W"+i).value;
+			let wd = gId("W"+i);
+			if (!wd) continue; // Skip if preset doesn't exist
+			wd = wd.value;
 			for(j=0;j<8;j++) {
-				gId("W"+i+j).checked=wd>>j&1;
+				let checkbox = gId("W"+i+j);
+				if (checkbox) checkbox.checked=wd>>j&1;
 			}
-			if ((wd&254) != 254 || (i<8 && (gN("M"+i).value != 1 || gN("D"+i).value != 1 || gN("P"+i).value != 12 || gN("E"+i).value != 31))) {
-				expand(gId("CB"+i),i); //expand macros with custom DOW or date range set
+			if ((wd&254) != 254 || (i<8 && (gN("M"+i) && gN("D"+i) && gN("P"+i) && gN("E"+i) && 
+				(gN("M"+i).value != 1 || gN("D"+i).value != 1 || gN("P"+i).value != 12 || gN("E"+i).value != 31)))) {
+				let cbElement = gId("CB"+i);
+				if (cbElement) expand(cbElement,i); //expand macros with custom DOW or date range set
 			}
 		}
+		updateAddButtonState();
 	}
 	function Wd()
 	{
-		a = [0,0,0,0,0,0,0,0,0,0];
-		for (i=0; i<10; i++) {
+		a = [];
+		for (i=0; i<currentPresetCount; i++) {
+			a[i] = 0;
 			m=1;
-			for(j=0;j<8;j++) { a[i]+=gId(("W"+i)+j).checked*m; m*=2;}
-			gId("W"+i).value=a[i];
+			for (j=0; j<8; j++) {
+				let checkbox = gId("W"+i+j);
+				if (checkbox && checkbox.checked) a[i]+=m;
+				m*=2;
+			}
+			let hiddenInput = gId("W"+i);
+			if (hiddenInput) hiddenInput.value = a[i];
 		}
 		if (d.Sf.LTR.value==="S") { d.Sf.LT.value = -1*parseFloat(d.Sf.LT.value); }
 		if (d.Sf.LNR.value==="W") { d.Sf.LN.value = -1*parseFloat(d.Sf.LN.value); }
@@ -207,7 +332,10 @@
 		<a href="https://kno.wled.ge/features/macros/#analog-button" target="_blank">Analog Button setup</a>
 		<h3>Time-controlled presets</h3>
 		<div style="display: inline-block">
-		<table id="TMT" style="min-width:330px;"></table>
+		<table id="TMT" style="min-width:380px; margin: 0 auto;"></table>
+		<br>
+		<button type="button" id="addPresetBtn" onclick="addTimePreset()">+</button>
+		<button type="button" id="removePresetBtn" onclick="removeLastPreset()" style="margin-left: 5px;">-</button>
 		</div>
 		<hr>
 		<button type="button" onclick="B()">Back</button><button type="submit">Save</button>

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -116,11 +116,11 @@ bool loadSchedule() {
         int p  = e["p"].as<int>();
 
         // Validate ranges to prevent bad data
-        if (sm < 0 || sm > 12 || em < 0 || em > 12 ||
-            sd < 0 || sd > 31 || ed < 0 || ed > 31 ||
+        if (sm < 1 || sm > 12 || em < 1 || em > 12 ||
+            sd < 1 || sd > 31 || ed < 1 || ed > 31 ||
             h  < 0 || h  > 23 || m  < 0 || m  > 59 ||
             r  < 0 || r  > 127|| p  < 1 || p  > 250) {
-            DEBUG_PRINTF_P(PSTR("[Schedule] Invalid values in event %u, skipping\n"), numScheduleEvents);
+            DEBUG_PRINTF_P(PSTR("[Schedule] Invalid values in event %u, skipping\n"), (uint16_t)scheduleEvents.size());
             continue;
         }
 

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -2,7 +2,7 @@
 // Handles reading, parsing, and checking the preset schedule from schedule.json
 
 #include "schedule.h"
-#include <WLED.h>
+#include "wled.h"
 #include <time.h>
 
 #define SCHEDULE_FILE "/schedule.json"

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #define SCHEDULE_FILE "/schedule.json"
+#define SCHEDULE_JSON_BUFFER_SIZE 4096
 
 // Array to hold scheduled events, max size defined in schedule.h
 ScheduleEvent scheduleEvents[MAX_SCHEDULE_EVENTS];
@@ -96,7 +97,7 @@ bool loadSchedule() {
         return false;
     }
 
-    DynamicJsonDocument doc(4096);
+    DynamicJsonDocument doc(SCHEDULE_JSON_BUFFER_SIZE);
     DeserializationError error = deserializeJson(doc, file);
     file.close();  // Always close file before releasing lock
 

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -16,14 +16,12 @@ uint8_t numScheduleEvents = 0; // Current count of loaded schedule entries
 bool isTodayInRange(uint8_t sm, uint8_t sd, uint8_t em, uint8_t ed, uint8_t cm, uint8_t cd)
 {
     // Handles ranges that wrap over the year end, e.g., Dec to Jan
-    if (sm < em || (sm == em && sd <= ed))
-    {
+    if (sm < em || (sm == em && sd <= ed)) {
         // Normal range within a year
         return (cm > sm || (cm == sm && cd >= sd)) &&
                (cm < em || (cm == em && cd <= ed));
     }
-    else
-    {
+    else {
         // Range wraps year-end (e.g., Nov 20 to Feb 10)
         return (cm > sm || (cm == sm && cd >= sd)) ||
                (cm < em || (cm == em && cd <= ed));
@@ -53,8 +51,7 @@ void checkSchedule() {
     DEBUG_PRINTF_P(PSTR("[Schedule] Checking schedule at %02u:%02u\n"), hr, min);
 
     // Iterate through all scheduled events
-    for (uint8_t i = 0; i < numScheduleEvents; i++)
-    {
+    for (uint8_t i = 0; i < numScheduleEvents; i++) {
         const ScheduleEvent &e = scheduleEvents[i];
 
         // Skip if hour or minute doesn't match current time
@@ -68,15 +65,13 @@ void checkSchedule() {
             match = true;
 
         // Otherwise check if current date is within start and end date range
-        if (e.startMonth)
-        {
+        if (e.startMonth) {
             if (isTodayInRange(e.startMonth, e.startDay, e.endMonth, e.endDay, cm, cd))
                 match = true;
         }
 
         // If match, apply preset and print debug
-        if (match)
-        {
+        if (match) {
             applyPreset(e.presetId);
             DEBUG_PRINTF_P(PSTR("[Schedule] Applying preset %u at %02u:%02u\n"), e.presetId, hr, min);
         }

--- a/wled00/schedule.cpp
+++ b/wled00/schedule.cpp
@@ -1,0 +1,147 @@
+// schedule.cpp
+// Handles reading, parsing, and checking the preset schedule from schedule.json
+
+#include "schedule.h"
+#include <WLED.h>
+#include <time.h>
+
+#define SCHEDULE_FILE "/schedule.json"
+
+// Array to hold scheduled events, max size defined in schedule.h
+ScheduleEvent scheduleEvents[MAX_SCHEDULE_EVENTS];
+uint8_t numScheduleEvents = 0; // Current count of loaded schedule entries
+
+// Helper function to check if current date (cm, cd) is within the event's start and end date range
+bool isTodayInRange(uint8_t sm, uint8_t sd, uint8_t em, uint8_t ed, uint8_t cm, uint8_t cd)
+{
+    // Handles ranges that wrap over the year end, e.g., Dec to Jan
+    if (sm < em || (sm == em && sd <= ed))
+    {
+        // Normal range within a year
+        return (cm > sm || (cm == sm && cd >= sd)) &&
+               (cm < em || (cm == em && cd <= ed));
+    }
+    else
+    {
+        // Range wraps year-end (e.g., Nov 20 to Feb 10)
+        return (cm > sm || (cm == sm && cd >= sd)) ||
+               (cm < em || (cm == em && cd <= ed));
+    }
+}
+
+// Checks current time against schedule entries and applies matching presets
+void checkSchedule() {
+    static int lastMinute = -1; // To avoid multiple triggers within the same minute
+
+    time_t now = localTime;
+    if (now < 100000) return; // Invalid or uninitialized time guard
+
+    struct tm* timeinfo = localtime(&now);
+
+    int thisMinute = timeinfo->tm_min + timeinfo->tm_hour * 60;
+    if (thisMinute == lastMinute) return; // Already checked this minute
+    lastMinute = thisMinute;
+
+    // Extract date/time components for easier use
+    uint8_t cm = timeinfo->tm_mon + 1; // Month [1-12]
+    uint8_t cd = timeinfo->tm_mday;    // Day of month [1-31]
+    uint8_t wday = timeinfo->tm_wday;  // Weekday [0-6], Sunday=0
+    uint8_t hr = timeinfo->tm_hour;    // Hour [0-23]
+    uint8_t min = timeinfo->tm_min;    // Minute [0-59]
+
+    DEBUG_PRINTF_P(PSTR("[Schedule] Checking schedule at %02u:%02u\n"), hr, min);
+
+    // Iterate through all scheduled events
+    for (uint8_t i = 0; i < numScheduleEvents; i++)
+    {
+        const ScheduleEvent &e = scheduleEvents[i];
+
+        // Skip if hour or minute doesn't match current time
+        if (e.hour != hr || e.minute != min)
+            continue;
+
+        bool match = false;
+
+        // Check if repeat mask matches current weekday (bitmask with Sunday=LSB)
+        if (e.repeatMask && ((e.repeatMask >> wday) & 0x01))
+            match = true;
+
+        // Otherwise check if current date is within start and end date range
+        if (e.startMonth)
+        {
+            if (isTodayInRange(e.startMonth, e.startDay, e.endMonth, e.endDay, cm, cd))
+                match = true;
+        }
+
+        // If match, apply preset and print debug
+        if (match)
+        {
+            applyPreset(e.presetId);
+            DEBUG_PRINTF_P(PSTR("[Schedule] Applying preset %u at %02u:%02u\n"), e.presetId, hr, min);
+        }
+    }
+}
+
+// Loads schedule events from the schedule JSON file
+// Returns true if successful, false on error or missing file
+bool loadSchedule() {
+    if (!WLED_FS.exists(SCHEDULE_FILE)) return false;
+
+    // Acquire JSON buffer lock to prevent concurrent access
+    if (!requestJSONBufferLock(7)) return false;
+
+    File file = WLED_FS.open(SCHEDULE_FILE, "r");
+    if (!file) {
+        releaseJSONBufferLock();
+        return false;
+    }
+
+    DynamicJsonDocument doc(4096);
+    DeserializationError error = deserializeJson(doc, file);
+    file.close();  // Always close file before releasing lock
+
+    if (error) {
+        DEBUG_PRINTF_P(PSTR("[Schedule] JSON parse failed: %s\n"), error.c_str());
+        releaseJSONBufferLock();
+        return false;
+    }
+
+    numScheduleEvents = 0;
+    for (JsonObject e : doc.as<JsonArray>()) {
+        if (numScheduleEvents >= MAX_SCHEDULE_EVENTS) break;
+
+        // Read and validate fields with type safety
+        int sm = e["sm"].as<int>();
+        int sd = e["sd"].as<int>();
+        int em = e["em"].as<int>();
+        int ed = e["ed"].as<int>();
+        int r  = e["r"].as<int>();
+        int h  = e["h"].as<int>();
+        int m  = e["m"].as<int>();
+        int p  = e["p"].as<int>();
+
+        // Validate ranges to prevent bad data
+        if (sm < 1 || sm > 12 || em < 1 || em > 12 ||
+            sd < 1 || sd > 31 || ed < 1 || ed > 31 ||
+            h  < 0 || h  > 23 || m  < 0 || m  > 59 ||
+            r  < 0 || r  > 127|| p  < 1 || p  > 250) {
+            DEBUG_PRINTF_P(PSTR("[Schedule] Invalid values in event %u, skipping\n"), numScheduleEvents);
+            continue;
+        }
+
+        // Store event in the array
+        scheduleEvents[numScheduleEvents++] = {
+            (uint8_t)sm, (uint8_t)sd,
+            (uint8_t)em, (uint8_t)ed,
+            (uint8_t)r,  (uint8_t)h,
+            (uint8_t)m,  (uint8_t)p
+        };
+    }
+
+    DEBUG_PRINTF_P(PSTR("[Schedule] Loaded %u schedule entries from schedule.json\n"), numScheduleEvents);
+
+    // Release JSON buffer lock after finishing
+    releaseJSONBufferLock();
+
+    return true;
+}

--- a/wled00/schedule.h
+++ b/wled00/schedule.h
@@ -1,0 +1,27 @@
+// schedule.h
+// Defines the schedule event data structure and declares schedule-related functions
+
+#pragma once
+
+#include <stdint.h>
+
+// Maximum number of schedule events supported
+#define MAX_SCHEDULE_EVENTS 32
+
+// Structure representing one scheduled event
+struct ScheduleEvent {
+  uint8_t startMonth;  // Starting month of the schedule event (1-12)
+  uint8_t startDay;    // Starting day of the schedule event (1-31)
+  uint8_t endMonth;    // Ending month of the schedule event (1-12)
+  uint8_t endDay;      // Ending day of the schedule event (1-31)
+  uint8_t repeatMask;  // Bitmask indicating repeat days of the week (bit0=Sunday ... bit6=Saturday)
+  uint8_t hour;        // Hour of day when event triggers (0-23)
+  uint8_t minute;      // Minute of hour when event triggers (0-59)
+  uint8_t presetId;    // Preset number to apply when event triggers (1-250)
+};
+
+// Loads the schedule from the JSON file; returns true if successful
+bool loadSchedule();
+
+// Checks current time against schedule and applies any matching preset
+void checkSchedule();

--- a/wled00/schedule.h
+++ b/wled00/schedule.h
@@ -8,16 +8,19 @@
 // Maximum number of schedule events supported
 #define MAX_SCHEDULE_EVENTS 32
 
-// Structure representing one scheduled event
 struct ScheduleEvent {
-  uint8_t startMonth;  // Starting month of the schedule event (1-12)
-  uint8_t startDay;    // Starting day of the schedule event (1-31)
-  uint8_t endMonth;    // Ending month of the schedule event (1-12)
-  uint8_t endDay;      // Ending day of the schedule event (1-31)
-  uint8_t repeatMask;  // Bitmask indicating repeat days of the week (bit0=Sunday ... bit6=Saturday)
-  uint8_t hour;        // Hour of day when event triggers (0-23)
-  uint8_t minute;      // Minute of hour when event triggers (0-59)
-  uint8_t presetId;    // Preset number to apply when event triggers (1-250)
+  uint8_t startMonth : 4;  // 0–12 (0 means no date range)
+  uint8_t startDay   : 5;  // 0–31
+
+  uint8_t endMonth   : 4;  // 0–12
+  uint8_t endDay     : 5;  // 0–31
+
+  uint8_t repeatMask : 7;  // bitmask for days of week (Sun=bit0 .. Sat=bit6)
+
+  uint8_t hour       : 5;  // 0–23
+  uint8_t minute     : 6;  // 0–59
+
+  uint8_t presetId;        // 1–250
 };
 
 // Loads the schedule from the JSON file; returns true if successful
@@ -25,3 +28,6 @@ bool loadSchedule();
 
 // Checks current time against schedule and applies any matching preset
 void checkSchedule();
+
+// Checks if the current date is within the specified range
+bool isTodayInRange(uint8_t sm, uint8_t sd, uint8_t em, uint8_t ed, uint8_t cm, uint8_t cd);

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -2,6 +2,7 @@
 #include "wled.h"
 #include "wled_ethernet.h"
 #include <Arduino.h>
+#include "schedule.h"
 
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
 #include "soc/soc.h"
@@ -54,6 +55,7 @@ void WLED::loop()
 #endif
 
   handleTime();
+  checkSchedule();
   #ifndef WLED_DISABLE_INFRARED
   handleIR();        // 2nd call to function needed for ESP32 to return valid results -- should be good for ESP8266, too
   #endif
@@ -413,6 +415,8 @@ void WLED::setup()
   initPresetsFile();
 #endif
   updateFSInfo();
+
+  loadSchedule();   // Load schedule from file on startup
 
   // generate module IDs must be done before AP setup
   escapedMac = WiFi.macAddress();

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -26,6 +26,8 @@ static const char s_rebooting  [] PROGMEM = "Rebooting now...";
 static const char s_notimplemented[] PROGMEM = "Not implemented";
 static const char s_accessdenied[]   PROGMEM = "Access Denied";
 static const char _common_js[]       PROGMEM = "/common.js";
+static const char SCHEDULE_JSON_PATH[] PROGMEM = "/schedule.json";
+static const char SCHEDULE_JSON_TMP_PATH[] PROGMEM = "/schedule.json.tmp";
 
 //Is this an IP?
 static bool isIp(const String &str) {
@@ -189,8 +191,8 @@ static void handleUpload(AsyncWebServerRequest *request, const String &filename,
     }
 
     // Special case: schedule.json upload uses temp file
-    if (finalname.equals(F("/schedule.json"))) {
-      request->_tempFile = WLED_FS.open("/schedule.json.tmp", "w");
+    if (finalname.equals(FPSTR(SCHEDULE_JSON_PATH))) {
+      request->_tempFile = WLED_FS.open(FPSTR(SCHEDULE_JSON_TMP_PATH), "w");
       DEBUG_PRINTLN(F("Uploading to /schedule.json.tmp"));
     }
     else {
@@ -219,13 +221,13 @@ static void handleUpload(AsyncWebServerRequest *request, const String &filename,
     if (request->_tempFile)
       request->_tempFile.close();
 
-    if (finalname.equals(F("/schedule.json"))) {
+    if (finalname.equals(FPSTR(SCHEDULE_JSON_PATH))) {
       // Atomically replace old file
       // First try rename (which overwrites on most filesystems)
-      if (!WLED_FS.rename("/schedule.json.tmp", "/schedule.json")) {
+      if (!WLED_FS.rename(FPSTR(SCHEDULE_JSON_TMP_PATH), FPSTR(SCHEDULE_JSON_PATH))) {
         // If rename failed, try remove then rename
-        WLED_FS.remove("/schedule.json");
-        if (!WLED_FS.rename("/schedule.json.tmp", "/schedule.json")) {
+        WLED_FS.remove(FPSTR(SCHEDULE_JSON_PATH));
+        if (!WLED_FS.rename(FPSTR(SCHEDULE_JSON_TMP_PATH), FPSTR(SCHEDULE_JSON_PATH))) {
           DEBUG_PRINTLN(F("[Schedule] Failed to replace schedule file"));
           request->send(500, FPSTR(CONTENT_TYPE_PLAIN), F("Failed to save schedule file."));
           return;

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -175,47 +175,38 @@ static String msgProcessor(const String& var)
   return String();
 }
 
-static void handleUpload(AsyncWebServerRequest *request, const String &filename, size_t index, uint8_t *data, size_t len, bool isFinal)
-{
-  if (!correctPIN)
-  {
+static void handleUpload(AsyncWebServerRequest *request, const String &filename, size_t index, uint8_t *data, size_t len, bool isFinal){
+  if (!correctPIN) {
     if (isFinal)
       request->send(401, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_unlock_cfg));
     return;
   }
 
   String finalname = filename;
-  if (!index)
-  {
-    if (finalname.charAt(0) != '/')
-    {
+  if (!index) {
+    if (finalname.charAt(0) != '/') {
       finalname = '/' + finalname; // prepend slash if missing
     }
 
     // Special case: schedule.json upload uses temp file
-    if (finalname.equals(F("/schedule.json")))
-    {
+    if (finalname.equals(F("/schedule.json"))) {
       request->_tempFile = WLED_FS.open("/schedule.json.tmp", "w");
       DEBUG_PRINTLN(F("Uploading to /schedule.json.tmp"));
     }
-    else
-    {
+    else {
       request->_tempFile = WLED_FS.open(finalname, "w");
       DEBUG_PRINTF_P(PSTR("Uploading %s\n"), finalname.c_str());
 
-      if (finalname.equals(FPSTR(getPresetsFileName())))
-      {
+      if (finalname.equals(FPSTR(getPresetsFileName()))) {
         presetsModifiedTime = toki.second();
       }
     }
   }
 
   // Write chunk
-  if (len && request->_tempFile)
-  {
+  if (len && request->_tempFile) {
     size_t written = request->_tempFile.write(data, len);
-    if (written != len)
-    {
+    if (written != len) {
       DEBUG_PRINTLN(F("File write error during upload"));
       request->_tempFile.close();
       request->_tempFile = File(); // invalidate file handle
@@ -224,21 +215,17 @@ static void handleUpload(AsyncWebServerRequest *request, const String &filename,
   }
 
   // Finalize upload
-  if (isFinal)
-  {
+  if (isFinal) {
     if (request->_tempFile)
       request->_tempFile.close();
 
-    if (finalname.equals(F("/schedule.json")))
-    {
+    if (finalname.equals(F("/schedule.json"))) {
       // Atomically replace old file
       // First try rename (which overwrites on most filesystems)
-      if (!WLED_FS.rename("/schedule.json.tmp", "/schedule.json"))
-      {
+      if (!WLED_FS.rename("/schedule.json.tmp", "/schedule.json")) {
         // If rename failed, try remove then rename
         WLED_FS.remove("/schedule.json");
-        if (!WLED_FS.rename("/schedule.json.tmp", "/schedule.json"))
-        {
+        if (!WLED_FS.rename("/schedule.json.tmp", "/schedule.json")) {
           DEBUG_PRINTLN(F("[Schedule] Failed to replace schedule file"));
           request->send(500, FPSTR(CONTENT_TYPE_PLAIN), F("Failed to save schedule file."));
           return;
@@ -248,8 +235,7 @@ static void handleUpload(AsyncWebServerRequest *request, const String &filename,
       DEBUG_PRINTLN(F("[Schedule] Upload complete and applied."));
 
       // Apply new schedule immediately
-      if (!loadSchedule())
-      {
+      if (!loadSchedule()) {
         DEBUG_PRINTLN(F("[Schedule] Failed to load new schedule"));
         request->send(500, FPSTR(CONTENT_TYPE_PLAIN), F("Schedule uploaded but failed to load."));
         return;
@@ -257,15 +243,12 @@ static void handleUpload(AsyncWebServerRequest *request, const String &filename,
     }
     else
     {
-      if (filename.indexOf(F("cfg.json")) >= 0)
-      {
+      if (filename.indexOf(F("cfg.json")) >= 0) {
         doReboot = true;
         request->send(200, FPSTR(CONTENT_TYPE_PLAIN), F("Configuration restore successful.\nRebooting..."));
       }
-      else
-      {
-        if (filename.indexOf(F("palette")) >= 0 && filename.indexOf(F(".json")) >= 0)
-        {
+      else {
+        if (filename.indexOf(F("palette")) >= 0 && filename.indexOf(F(".json")) >= 0) {
           loadCustomPalettes();
         }
         request->send(200, FPSTR(CONTENT_TYPE_PLAIN), F("File Uploaded!"));


### PR DESCRIPTION
_Note: This is a cleaner reimplementation of the scheduling system originally proposed in PR #4772. It replaces that version with improved structure and maintainability._

_Disclaimer: This is a conceptual implementation intended to look at improved approaches to scheduling in WLED. It primarily serves as a foundation on how best to evolve or replace the existing timer system._

**What this PR Does**
Introduces a lightweight, modular scheduling system supporting up to 32 schedule events (vs. the legacy ~10 timer slots).

Each schedule event supports:
Time-based preset triggers (hour + minute)
Optional date ranges (start/end month and day)
Weekly repeat bitmasks for specific weekdays
Scheduling data is stored and loaded from a simple JSON file (schedule.json), making it easier to backup and edit outside the device.
The scheduler runs in the main loop, applying presets once per minute when conditions match.

**Comparison to Existing Timer System**

- The existing timer system is limited in capacity and tightly coupled to macros, with some legacy code complexity.
- Functionality overlaps _significantly_ — both systems trigger presets on time/date conditions — but the new scheduler lays groundwork for future extensibility.
- It does not yet have UI editing features.
- The existing timers include some specialized features (sunrise/sunset, hour 24 triggers) which are not replicated here.

**Why Some Features Are Not Included Yet**
This scheduler focuses on being lightweight and efficient to make it feasible as a default built-in feature, rather than a usermod. As such, it currently:
- Triggers only presets (no macros or complex HTTP actions) to minimize code size and complexity.
- Does not yet handle sunrise/sunset events or other advanced triggers, which add significant logic and state tracking.
The aim is to provide a clean, minimal core that covers the most common scheduling needs with minimal RAM and CPU overhead.

**Thoughts on Combining with the Existing Timer System**

- The existing timer system already supports things like sunrise/sunset and running macros.
- We could dynamically add timers to either system depending on whether they fit the new scheduler’s style, but having both running at the same time feels a bit unnecessary.
- Combining both into one system is possible but could make the code more complex and harder to keep lightweight.

Feedback on how to best handle this would be helpful.


**Technical details**




**How it works**

- A schedule.json can be uploaded via /settings/time
- The schedule system loads this file on startup and when a new schedule.json is uploaded
- Each schedule entry contains a time, an optional date range, and/or a weekly repeat bitmask.
- When the current time matches an entry, the configured preset is applied.
- The checkSchedule() gets called in the wled.cpp loop() and if it was triggered less than a minute ago doesn't (fully) trigger.


**JSON Formating**

- sm, sd, em, ed: Start/end month & day (date range)
- r: Weekly repeat bitmask (bit 0 = Sunday, bit 6 = Saturday)
- h, m: Hour and minute to trigger
- p: Preset ID to apply
```JSON
[
  {
    "sm": 7,
    "sd": 4,
    "em": 7,
    "ed": 4,
    "r": 0,
    "h": 20,
    "m": 30,
    "p": 5
  },
  {
    "sm": 0,
    "sd": 0,
    "em": 0,
    "ed": 0,
    "r": 34,
    "h": 7,
    "m": 15,
    "p": 2
  }
]
 ```

Explanation:
First entry: Runs preset 5 on July 4th at 20:30 every year.

Second entry: Runs preset 2 every Monday and Friday at 07:15.
(Repeat bitmask 34 = 0b100010 = Monday and Friday)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic time-controlled presets with add/remove capabilities in the time settings.
  * Added schedule-based automation supporting date ranges, repeat options, and preset triggers.
  * Enabled upload and download of preset schedules via the time settings interface.

* **Bug Fixes**
  * Enhanced schedule file upload with atomic replacement and immediate application.
  * Improved error handling during file uploads for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->