### PR TITLE
Allow to define default led effect

### DIFF
--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -742,6 +742,7 @@ WLED_GLOBAL bool notifyHue    _INIT(true);                        // send notifi
 #ifndef DEFAULT_LED_EFFECT
 #define DEFAULT_LED_EFFECT 0
 #endif
+static_assert(DEFAULT_LED_EFFECT >= 0 && DEFAULT_LED_EFFECT < MODE_COUNT, "DEFAULT_LED_EFFECT must be between 0 and MODE_COUNT-1");
 WLED_GLOBAL byte effectCurrent _INIT(DEFAULT_LED_EFFECT);
 WLED_GLOBAL byte effectSpeed _INIT(128);
 WLED_GLOBAL byte effectIntensity _INIT(128);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -739,7 +739,10 @@ WLED_GLOBAL bool notifyHue    _INIT(true);                        // send notifi
 #endif
 
 // effects
-WLED_GLOBAL byte effectCurrent _INIT(0);
+#ifndef DEFAULT_LED_EFFECT
+#define DEFAULT_LED_EFFECT 0
+#endif
+WLED_GLOBAL byte effectCurrent _INIT(DEFAULT_LED_EFFECT);
 WLED_GLOBAL byte effectSpeed _INIT(128);
 WLED_GLOBAL byte effectIntensity _INIT(128);
 WLED_GLOBAL byte effectPalette _INIT(0);


### PR DESCRIPTION
Allows you to declare a default LED (selected after first power on) effect via `#define DEFAULT_LED_EFFECT <effect number>`
Example: `#define DEFAULT_LED_EFFECT 157` will use "Gravcentric" effect on first startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The default LED effect can now be customized through a configuration setting, allowing users to set their preferred initial effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->