### PR TITLE
Bootloop detection & recovery

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -774,6 +774,19 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
 
 static const char s_cfg_json[] PROGMEM = "/cfg.json";
+static const char s_cfg_bak[]  PROGMEM = "/cfg.bak";
+
+void backupConfig() {
+  DEBUG_PRINTLN(F("Backing up current config to /cfg.bak..."));
+  Serial.println(F("Backing up current config to /cfg.bak..."));
+  copyFile(FPSTR(s_cfg_json), FPSTR(s_cfg_bak));
+}
+
+void restoreConfig() {
+  DEBUG_PRINTLN(F("Restoring backup from /cfg.bak..."));
+  Serial.println(F("Restoring backup from /cfg.bak..."));
+  copyFile(FPSTR(s_cfg_bak), FPSTR(s_cfg_json));
+}
 
 bool deserializeConfigFromFS() {
   [[maybe_unused]] bool success = deserializeConfigSec();
@@ -800,6 +813,7 @@ bool deserializeConfigFromFS() {
 
 void serializeConfigToFS() {
   serializeConfigSec();
+  backupConfig(); // backup before writing new config
 
   DEBUG_PRINTLN(F("Writing settings to /cfg.json..."));
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -782,6 +782,10 @@ bool restoreConfig() {
   return restoreFile(s_cfg_json);
 }
 
+bool verifyConfig() {
+  return validateJsonFile(s_cfg_json);
+}
+
 // rename config file and reboot
 void resetConfig() {
   DEBUG_PRINTLN(F("Reset config"));

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -774,18 +774,23 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
 
 static const char s_cfg_json[] PROGMEM = "/cfg.json";
-static const char s_cfg_bak[]  PROGMEM = "/cfg.bak";
+static const char s_cfg_bak[]  PROGMEM = "/cfg.bak.json";
 
-void backupConfig() {
-  DEBUG_PRINTLN(F("Backing up current config to /cfg.bak..."));
-  Serial.println(F("Backing up current config to /cfg.bak..."));
-  copyFile(FPSTR(s_cfg_json), FPSTR(s_cfg_bak));
+bool backupConfig() {
+  DEBUG_PRINTLN(F("Backup config"));
+  return copyFile(FPSTR(s_cfg_json), FPSTR(s_cfg_bak));
 }
 
-void restoreConfig() {
-  DEBUG_PRINTLN(F("Restoring backup from /cfg.bak..."));
-  Serial.println(F("Restoring backup from /cfg.bak..."));
-  copyFile(FPSTR(s_cfg_bak), FPSTR(s_cfg_json));
+bool restoreConfig() {
+  DEBUG_PRINTLN(F("Restore config"));
+  return copyFile(FPSTR(s_cfg_bak), FPSTR(s_cfg_json));
+}
+
+// rename config file and reboot
+void resetConfig() {
+  DEBUG_PRINTLN(F("Reset config"));
+  WLED_FS.rename(FPSTR(s_cfg_json), String(FPSTR(s_cfg_bak)));
+  doReboot = true;
 }
 
 bool deserializeConfigFromFS() {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -772,24 +772,23 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   return (doc["sv"] | true);
 }
 
-
 static const char s_cfg_json[] PROGMEM = "/cfg.json";
-static const char s_cfg_bak[]  PROGMEM = "/cfg.bak.json";
 
 bool backupConfig() {
-  DEBUG_PRINTLN(F("Backup config"));
-  return copyFile(FPSTR(s_cfg_json), FPSTR(s_cfg_bak));
+  return backupFile(s_cfg_json);
 }
 
 bool restoreConfig() {
-  DEBUG_PRINTLN(F("Restore config"));
-  return copyFile(FPSTR(s_cfg_bak), FPSTR(s_cfg_json));
+  return restoreFile(s_cfg_json);
 }
 
 // rename config file and reboot
 void resetConfig() {
   DEBUG_PRINTLN(F("Reset config"));
-  WLED_FS.rename(FPSTR(s_cfg_json), String(FPSTR(s_cfg_bak)));
+  char backupname[32];
+  strcpy(backupname, s_cfg_json);
+  strcat(backupname, ".rst.json");
+  WLED_FS.rename(s_cfg_json, backupname);
   doReboot = true;
 }
 

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -226,7 +226,7 @@ inline bool writeObjectToFileUsingId(const String &file, uint16_t id, const Json
 inline bool writeObjectToFile(const String &file, const char* key, const JsonDocument* content) { return writeObjectToFile(file.c_str(), key, content); };
 inline bool readObjectFromFileUsingId(const String &file, uint16_t id, JsonDocument* dest, const JsonDocument* filter = nullptr) { return readObjectFromFileUsingId(file.c_str(), id, dest); };
 inline bool readObjectFromFile(const String &file, const char* key, JsonDocument* dest, const JsonDocument* filter = nullptr) { return readObjectFromFile(file.c_str(), key, dest); };
-bool copyFile(const String &src_path, const String &dst_path);
+bool copyFile(const char* src_path, const char* dst_path);
 bool backupFile(const char* filename);
 bool restoreFile(const char* filename);
 void dumpFilesToSerial();

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -24,8 +24,9 @@ void handleIO();
 void IRAM_ATTR touchButtonISR();
 
 //cfg.cpp
-void backupConfig();
-void restoreConfig();
+bool backupConfig();
+bool restoreConfig();
+void resetConfig();
 bool deserializeConfig(JsonObject doc, bool fromFS = false);
 bool deserializeConfigFromFS();
 bool deserializeConfigSec();
@@ -583,10 +584,9 @@ extern "C" {
 #define d_free free
 #endif
 
-
-void bootloopCheckOTA(); // track bootloop actions, call this in setup() to restore config or reset it
+void handleBootLoop();   // detect and handle boot loops
 #ifndef ESP8266
-bool detectBootLoop();
+void bootloopCheckOTA(); // swap boot image if boot loop is detected instead of restoring config
 #endif
 // RAII guard class for the JSON Buffer lock
 // Modeled after std::lock_guard

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -24,6 +24,8 @@ void handleIO();
 void IRAM_ATTR touchButtonISR();
 
 //cfg.cpp
+void backupConfig();
+void restoreConfig();
 bool deserializeConfig(JsonObject doc, bool fromFS = false);
 bool deserializeConfigFromFS();
 bool deserializeConfigSec();
@@ -223,6 +225,7 @@ inline bool writeObjectToFileUsingId(const String &file, uint16_t id, const Json
 inline bool writeObjectToFile(const String &file, const char* key, const JsonDocument* content) { return writeObjectToFile(file.c_str(), key, content); };
 inline bool readObjectFromFileUsingId(const String &file, uint16_t id, JsonDocument* dest, const JsonDocument* filter = nullptr) { return readObjectFromFileUsingId(file.c_str(), id, dest); };
 inline bool readObjectFromFile(const String &file, const char* key, JsonDocument* dest, const JsonDocument* filter = nullptr) { return readObjectFromFile(file.c_str(), key, dest); };
+bool copyFile(const String &src_path, const String &dst_path);
 
 //hue.cpp
 void handleHue();
@@ -580,6 +583,11 @@ extern "C" {
 #define d_free free
 #endif
 
+
+void bootloopCheckOTA(); // track bootloop actions, call this in setup() to restore config or reset it
+#ifndef ESP8266
+bool detectBootLoop();
+#endif
 // RAII guard class for the JSON Buffer lock
 // Modeled after std::lock_guard
 class JSONBufferGuard {

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -26,6 +26,7 @@ void IRAM_ATTR touchButtonISR();
 //cfg.cpp
 bool backupConfig();
 bool restoreConfig();
+bool verifyConfig();
 void resetConfig();
 bool deserializeConfig(JsonObject doc, bool fromFS = false);
 bool deserializeConfigFromFS();
@@ -229,6 +230,7 @@ inline bool readObjectFromFile(const String &file, const char* key, JsonDocument
 bool copyFile(const char* src_path, const char* dst_path);
 bool backupFile(const char* filename);
 bool restoreFile(const char* filename);
+bool validateJsonFile(const char* filename);
 void dumpFilesToSerial();
 
 //hue.cpp

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -227,6 +227,9 @@ inline bool writeObjectToFile(const String &file, const char* key, const JsonDoc
 inline bool readObjectFromFileUsingId(const String &file, uint16_t id, JsonDocument* dest, const JsonDocument* filter = nullptr) { return readObjectFromFileUsingId(file.c_str(), id, dest); };
 inline bool readObjectFromFile(const String &file, const char* key, JsonDocument* dest, const JsonDocument* filter = nullptr) { return readObjectFromFile(file.c_str(), key, dest); };
 bool copyFile(const String &src_path, const String &dst_path);
+bool backupFile(const char* filename);
+bool restoreFile(const char* filename);
+void dumpFilesToSerial();
 
 //hue.cpp
 void handleHue();
@@ -584,9 +587,9 @@ extern "C" {
 #define d_free free
 #endif
 
-void handleBootLoop();   // detect and handle boot loops
+void handleBootLoop();   // detect and handle bootloops
 #ifndef ESP8266
-void bootloopCheckOTA(); // swap boot image if boot loop is detected instead of restoring config
+void bootloopCheckOTA(); // swap boot image if bootloop is detected instead of restoring config
 #endif
 // RAII guard class for the JSON Buffer lock
 // Modeled after std::lock_guard

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -440,25 +440,27 @@ bool handleFileRead(AsyncWebServerRequest* request, String path){
   return false;
 }
 
-// copy a file, delete dst_path if incomplete to prevent corrupted files
+// copy a file, delete destination file if incomplete to prevent corrupted files
 bool copyFile(const String &src_path, const String &dst_path) {
-  bool success = true;
-  if(!WLED_FS.exists(src_path)) {
-    return false;
-  }
+  DEBUG_PRINTLN(F("copyFile from ") + src_path + F(" to ") + dst_path);
+  if(!WLED_FS.exists(src_path)) return false;
+
+  bool success = false;
   File src = WLED_FS.open(src_path, "r");
   File dst = WLED_FS.open(dst_path, "w");
-  DEBUG_PRINTLN(F("copyFile from ") + src_path + F(" to ") + dst_path);
+
   if (src && dst) {
     uint8_t buf[128];
-    while (true) {
+    while (src.available() > 0) {
       size_t bytesRead = src.read(buf, sizeof(buf));
       if (bytesRead == 0) {
-        break; // EOF or error
+        success = false;
+        break; // error, no data read
       }
       size_t bytesWritten = dst.write(buf, bytesRead);
       if (bytesWritten != bytesRead) {
         success = false;
+        break; // error, not all data written
       }
     }
   }

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -514,7 +514,7 @@ bool restoreFile(const char* filename) {
 
 // print contents of all files in root dir to Serial except wsec files
 void dumpFilesToSerial() {
-  File rootdir = WLED_FS.open("/");
+  File rootdir = WLED_FS.open("/", "r");
   File rootfile = rootdir.openNextFile();
   while (rootfile) {
     size_t len = strlen(rootfile.name());

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -448,7 +448,7 @@ bool copyFile(const char* src_path, const char* dst_path) {
    return false;
   }
 
-  bool success = false;
+  bool success = true; // is set to false on error
   File src = WLED_FS.open(src_path, "r");
   File dst = WLED_FS.open(dst_path, "w");
 
@@ -466,6 +466,8 @@ bool copyFile(const char* src_path, const char* dst_path) {
         break; // error, not all data written
       }
     }
+  } else {
+    success = false; // error, could not open files
   }
   if(src) src.close();
   if(dst) dst.close();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -210,32 +210,6 @@ void WLED::loop()
 
   toki.resetTick();
 
-static unsigned long debugTime=0;
-
-if(millis() -debugTime>5000) {
-debugTime=millis();
-//Serial.printf_P(PSTR("Free heap: %u, Contiguous: %u\n"), getFreeHeapSize(), getContiguousFreeHeap());
-
-uint32_t rtcTime = esp_rtc_get_time_us() / 1000;
-
-Serial.printf("RTC time in ms: %lu\n", rtcTime); // update system time, this is needed for the RTC to work properly
-//Serial.printf("tracker: %lu\n", bl_actiontracker); // update system time, this is needed for the RTC to work properly
- // bl_actiontracker++; // debug!!!
-/*
-if(millis()  > 20000) {
-  // make it crash
-  int *p = nullptr; 
-  *p = 0x12345678; // write to null pointer
-}*/
-
-}
-/*
-// make it crash
-if(!bootLoopDetected) {
-  int *p = nullptr; 
-  *p = 0x12345678; // write to null pointer
-}*/
-
 #if WLED_WATCHDOG_TIMEOUT > 0
   // we finished our mainloop, reset the watchdog timer
   static unsigned long lastWDTFeed = 0;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -33,7 +33,7 @@ void WLED::reset()
   DEBUG_PRINTLN(F("WLED RESET"));
   ESP.restart();
 }
-
+#include "esp32/rtc.h"      // for bootloop detection TODO: remove this!!! debug only.
 void WLED::loop()
 {
   static uint32_t      lastHeap = UINT32_MAX;
@@ -209,6 +209,32 @@ void WLED::loop()
 #endif
 
   toki.resetTick();
+
+static unsigned long debugTime=0;
+
+if(millis() -debugTime>5000) {
+debugTime=millis();
+//Serial.printf_P(PSTR("Free heap: %u, Contiguous: %u\n"), getFreeHeapSize(), getContiguousFreeHeap());
+
+uint32_t rtcTime = esp_rtc_get_time_us() / 1000;
+
+Serial.printf("RTC time in ms: %lu\n", rtcTime); // update system time, this is needed for the RTC to work properly
+//Serial.printf("tracker: %lu\n", bl_actiontracker); // update system time, this is needed for the RTC to work properly
+ // bl_actiontracker++; // debug!!!
+/*
+if(millis()  > 20000) {
+  // make it crash
+  int *p = nullptr; 
+  *p = 0x12345678; // write to null pointer
+}*/
+
+}
+/*
+// make it crash
+if(!bootLoopDetected) {
+  int *p = nullptr; 
+  *p = 0x12345678; // write to null pointer
+}*/
 
 #if WLED_WATCHDOG_TIMEOUT > 0
   // we finished our mainloop, reset the watchdog timer
@@ -410,6 +436,22 @@ void WLED::setup()
 #ifdef WLED_ADD_EEPROM_SUPPORT
   else deEEP();
 #else
+/*
+// check for bootloop
+if (detectBootLoop()) {
+  restoreConfig();
+
+  // check if backup exists
+  if (WLED_FS.exists(FPSTR(s_cfg_backup))) {
+    // just delete the config and do not overwrite the backup
+    WLED_FS.remove(FPSTR(s_cfg_json));
+  }
+  WLED_FS.rename(FPSTR(s_cfg_json), FPSTR(s_cfg_backup));
+  //reboot:
+  DEBUG_PRINTLN(F("Rebooting..."));
+  delay(1000);
+  ESP.restart();
+}*/
   initPresetsFile();
 #endif
   updateFSInfo();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -425,6 +425,11 @@ void WLED::setup()
   WLED_SET_AP_SSID(); // otherwise it is empty on first boot until config is saved
   multiWiFi.push_back(WiFiConfig(CLIENT_SSID,CLIENT_PASS)); // initialise vector with default WiFi
 
+  if(!verifyConfig()) {
+    if(!restoreConfig()) {
+      resetConfig();
+    }
+  }
   DEBUG_PRINTLN(F("Reading config"));
   bool needsCfgSave = deserializeConfigFromFS();
   DEBUG_PRINTF_P(PSTR("heap %u\n"), ESP.getFreeHeap());

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -33,7 +33,7 @@ void WLED::reset()
   DEBUG_PRINTLN(F("WLED RESET"));
   ESP.restart();
 }
-#include "esp32/rtc.h"      // for bootloop detection TODO: remove this!!! debug only.
+
 void WLED::loop()
 {
   static uint32_t      lastHeap = UINT32_MAX;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -433,25 +433,12 @@ void WLED::setup()
     DEBUGFS_PRINTLN(F("FS failed!"));
     errorFlag = ERR_FS_BEGIN;
   }
+
+  handleBootLoop(); // check for bootloop and take action (requires WLED_FS)
+
 #ifdef WLED_ADD_EEPROM_SUPPORT
   else deEEP();
 #else
-/*
-// check for bootloop
-if (detectBootLoop()) {
-  restoreConfig();
-
-  // check if backup exists
-  if (WLED_FS.exists(FPSTR(s_cfg_backup))) {
-    // just delete the config and do not overwrite the backup
-    WLED_FS.remove(FPSTR(s_cfg_json));
-  }
-  WLED_FS.rename(FPSTR(s_cfg_json), FPSTR(s_cfg_backup));
-  //reboot:
-  DEBUG_PRINTLN(F("Rebooting..."));
-  delay(1000);
-  ESP.restart();
-}*/
   initPresetsFile();
 #endif
   updateFSInfo();

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -408,10 +408,8 @@ void initServer()
       serveMessage(request, 500, F("Update failed!"), F("Please check your file and retry!"), 254);
     } else {
       serveMessage(request, 200, F("Update successful!"), FPSTR(s_rebooting), 131);
-      // let the bootloop-checker know there was an OTA update
       #ifndef ESP8266
-      // set the bootlop action to ota revert
-      // todo: set bootloop action to config revert in config safe function
+      bootloopCheckOTA(); // let the bootloop-checker know there was an OTA update
       #endif
       doReboot = true;
     }

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -408,6 +408,11 @@ void initServer()
       serveMessage(request, 500, F("Update failed!"), F("Please check your file and retry!"), 254);
     } else {
       serveMessage(request, 200, F("Update successful!"), FPSTR(s_rebooting), 131);
+      // let the bootloop-checker know there was an OTA update
+      #ifndef ESP8266
+      // set the bootlop action to ota revert
+      // todo: set bootloop action to config revert in config safe function
+      #endif
       doReboot = true;
     }
   },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool isFinal){

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -429,8 +429,9 @@ void initServer()
       UsermodManager::onUpdateBegin(true); // notify usermods that update is about to begin (some may require task de-init)
       lastEditTime = millis(); // make sure PIN does not lock during update
       strip.suspend();
-      #ifdef ESP8266
+      backupConfig(); // backup current config in case the update ends badly
       strip.resetSegments();  // free as much memory as you can
+      #ifdef ESP8266
       Update.runAsync(true);
       #endif
       Update.begin((ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000);


### PR DESCRIPTION
- Add functions to detect and handle bootloops
- Add functions to handle file backup and restore
- Add some wrappers and function to dump .json files to serial

How boot loop detection works:
All ESPs have an internal timer that is persistent: this is used to determine intervals between boots. If the reported reset reason hints at a crash, a persistent counter is incremented. If this happens several times in a row, it’s boot looping.
To recover from a boot loop three steps are attempted
1. Load config from backup (backup is created before every config save)
2. Reset config by renaming the file: defaults are applied at next boot (different name than normal backup)
3. Swap to the other boot partition if possible (rollback)
4. If all of the above failed: keeps boot-looping but dumps all .json files to serial

Brownout detection
Bootloops due to brownout cannot be detected with the above method unless resorting to flash-stored variables. While possible, it is more complicated. The simple solution: if a brownout is detected, the config is restored from last backup: this will fix any immediate crashes after saving a bad choice. It will however also revert the last change if a brownout happens due to some other reason like setting the LEDs too bright but can’t account for hardware deficiency of user setups.

Backup are intentionally ending in .json so they can be displayed in file editor. Not sure this is the best idea: users could also download the file to view it, inexperienced users should not mess with the backups: should rather add a UI element to restore backups.

Ideas / additions based on this PR:
- Add a button to the welcome page if a config backup is found to „restore config from backup“
- Automatic backup of presets: add a variable „presetsNeedBackup“, save presets to a backup file next time the LEDs are off (large preset files cause delay if done at *runtime*). downside: reduces number of presets that fit in FS, so this may need a setting option to disable
- Add a serial command to invoke the .json dump


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device-side backup, restore, verification, and reset of configuration files.
  * File utilities for copying, comparing, validating JSON, restoring backups, and dumping JSON files to serial.
  * Automatic bootloop detection and staged recovery (config restore/reset and boot partition rollback where supported).

* **Improvements**
  * Configurations are backed up before overwrite and during updates.
  * Startup now validates and attempts recovery of configuration before use.
  * Improved resilience with automated multi-step recovery on repeated boot failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->