### PR TITLE
Update AsyncTCP (and AsyncWebServer)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -239,6 +239,7 @@ lib_deps =
   https://github.com/Aircoookie/GifDecoder#bc3af18
 build_flags =
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -D WLED_ENABLE_GIF
 
 [esp32]

--- a/platformio.ini
+++ b/platformio.ini
@@ -142,7 +142,7 @@ lib_deps =
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.8.3
     #https://github.com/makuna/NeoPixelBus.git#CoreShaderBeta
-    https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.1
+    https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.2
   # for I2C interface
     ;Wire
   # ESP-NOW library
@@ -234,7 +234,7 @@ lib_deps_compat =
 
 [esp32_all_variants]
 lib_deps =
-  esp32async/AsyncTCP @ 3.4.6
+  esp32async/AsyncTCP @ 3.4.7
   bitbank2/AnimatedGIF@^1.4.7
   https://github.com/Aircoookie/GifDecoder#bc3af18
 build_flags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -142,7 +142,7 @@ lib_deps =
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.8.3
     #https://github.com/makuna/NeoPixelBus.git#CoreShaderBeta
-    https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.0
+    https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.1
   # for I2C interface
     ;Wire
   # ESP-NOW library
@@ -234,7 +234,7 @@ lib_deps_compat =
 
 [esp32_all_variants]
 lib_deps =
-  willmmiles/AsyncTCP @ 1.3.1
+  esp32async/AsyncTCP @ 3.4.6
   bitbank2/AnimatedGIF@^1.4.7
   https://github.com/Aircoookie/GifDecoder#bc3af18
 build_flags =


### PR DESCRIPTION
Update to the latest upstream AsyncTCP library, which now includes most of the improvements from the willmmiles fork, and specifically includes a fix for the crashes reported at #4785.  (It is my intention to PR the remaining improvements from my fork there anyways; the additional scrutiny has been good for turning up bugs.)

Unfortunately, AsyncWebServer also must be updated with the same reference: if it points to a different library source, the PlatformIO build process can get quite confused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ESPAsyncWebServer and AsyncTCP library versions to newer releases for improved compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->