### PR TITLE
fix: Added platform_packages for esp32s2, c3, s3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -296,6 +296,7 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
 platform = ${esp32_idf_V4.platform}
+platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
@@ -315,6 +316,7 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
 platform = ${esp32_idf_V4.platform}
+platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
@@ -334,6 +336,7 @@ board_build.flash_mode = qio
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
 platform = ${esp32_idf_V4.platform}
+platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -DESP32


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Aligned ESP32‑S2, ESP32‑C3, and ESP32‑S3 build environments to use the same platform packages as the base ESP32 configuration.
  - Improves build consistency across ESP32 variants, reducing discrepancies and potential dependency mismatches.
  - Enhances reliability of firmware builds for these boards without altering features or runtime behavior.
  - No changes to flags, partitions, or libraries; this update is limited to build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->