### PR TITLE
Remove old V3 IDF

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -247,6 +247,7 @@ platform = ${esp32_idf_V4.platform}
 platform_packages =
 build_unflags = ${common.build_unflags}
 build_flags = ${esp32_idf_V4.build_flags}
+lib_deps = ${esp32_idf_V4.lib_deps}
 
 tiny_partitions = tools/WLED_ESP32_2MB_noOTA.csv
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
@@ -254,10 +255,7 @@ extended_partitions = tools/WLED_ESP32_4MB_700k_FS.csv
 big_partitions = tools/WLED_ESP32_4MB_256KB_FS.csv     ;; 1.8MB firmware, 256KB filesystem, coredump support
 large_partitions = tools/WLED_ESP32_8MB.csv
 extreme_partitions = tools/WLED_ESP32_16MB_9MB_FS.csv
-lib_deps =
-  https://github.com/lorol/LITTLEFS.git
-  ${esp32_all_variants.lib_deps}
-  ${env.lib_deps}
+
 board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 # additional build flags for audioreactive - must be applied globally
 AR_build_flags = ;; -fsingle-precision-constant ;; forces ArduinoFFT to use float math (2x faster)
@@ -477,6 +475,7 @@ build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"
 ;  -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
 lib_deps = ${esp32.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
+board_build.flash_mode = dio
 
 [env:esp32_wrover]
 extends = esp32_idf_V4

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover, usermods
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover, usermods
 
 src_dir  = ./wled00
 data_dir = ./wled00/data
@@ -243,17 +243,10 @@ build_flags =
   -D WLED_ENABLE_GIF
 
 [esp32]
-#platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
-platform = espressif32@3.5.0
-platform_packages = framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4
+platform = ${esp32_idf_V4.platform}
+platform_packages =
 build_unflags = ${common.build_unflags}
-build_flags = -g
-  -DARDUINO_ARCH_ESP32
-  #-DCONFIG_LITTLEFS_FOR_IDF_3_2
-  #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
-  -D LOROL_LITTLEFS
-  ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-  ${esp32_all_variants.build_flags}
+build_flags = ${esp32_idf_V4.build_flags}
 
 tiny_partitions = tools/WLED_ESP32_2MB_noOTA.csv
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
@@ -272,8 +265,7 @@ AR_lib_deps =  ;; for pre-usermod-library platformio_override compatibility
 
 
 [esp32_idf_V4]
-;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
-;; very similar to the normal ESP32 flags, but omitting Lorol LittleFS, as littlefs is included in the new framework already.
+;; build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
 ;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
@@ -290,7 +282,6 @@ lib_deps =
   ${esp32_all_variants.lib_deps}
   https://github.com/someweisguy/esp_dmx.git#47db25d
   ${env.lib_deps}
-board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
@@ -438,17 +429,6 @@ custom_usermods = audioreactive
 
 [env:esp32dev]
 board = esp32dev
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"ESP32\" #-D WLED_DISABLE_BROWNOUT_DET
-lib_deps = ${esp32.lib_deps}
-monitor_filters = esp32_exception_decoder
-board_build.partitions = ${esp32.default_partitions}
-
-[env:esp32dev_V4]
-board = esp32dev
 platform = ${esp32_idf_V4.platform}
 build_unflags = ${common.build_unflags}
 custom_usermods = audioreactive
@@ -487,23 +467,9 @@ board_upload.maximum_size = 16777216
 board_build.f_flash = 80000000L
 board_build.flash_mode = dio
 
-;[env:esp32dev_audioreactive]
-;board = esp32dev
-;platform = ${esp32.platform}
-;platform_packages = ${esp32.platform_packages}
-;custom_usermods = audioreactive
-;build_unflags = ${common.build_unflags}
-;build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"ESP32_audioreactive\" #-D WLED_DISABLE_BROWNOUT_DET
-;lib_deps = ${esp32.lib_deps}
-;monitor_filters = esp32_exception_decoder
-;board_build.partitions = ${esp32.default_partitions}
-;; board_build.f_flash = 80000000L
-;; board_build.flash_mode = dio
-
 [env:esp32_eth]
 board = esp32-poe
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
+platform = ${esp32_idf_V4.platform}
 upload_speed = 921600
 custom_usermods = audioreactive
 build_unflags = ${common.build_unflags}
@@ -514,7 +480,6 @@ board_build.partitions = ${esp32.default_partitions}
 
 [env:esp32_wrover]
 extends = esp32_idf_V4
-platform = ${esp32_idf_V4.platform}
 board = ttgo-t7-v14-mini32
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio


### PR DESCRIPTION
Make all ESP32 builds use the V4 ESP-IDF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster builds via a global build cache.
  * Support for an optional user override configuration.

* **Refactor**
  * Standardized ESP32 builds on an ESP-IDF v4 configuration.
  * Simplified and de-duplicated ESP32 environment settings; added a distinct V4-targeted environment.

* **Chores**
  * Defaults updated to prefer ESP-IDF v4 variants; removed legacy ESP32 audioreactive default.
  * Updated environment guidance including OTA/install cautions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->