### PR TITLE
Fix broken Sync button after 0.15 refactor

### DIFF
--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -733,10 +733,10 @@ WLED_GLOBAL bool receiveNotificationPalette    _INIT(true);       // apply palet
 WLED_GLOBAL bool receiveSegmentOptions         _INIT(false);      // apply segment options
 WLED_GLOBAL bool receiveSegmentBounds          _INIT(false);      // apply segment bounds (start, stop, offset)
 WLED_GLOBAL bool receiveDirect _INIT(true);                       // receive UDP/Hyperion realtime
-WLED_GLOBAL bool notifyDirect _INIT(false);                       // send notification if change via UI or HTTP API
-WLED_GLOBAL bool notifyButton _INIT(false);                       // send if updated by button or infrared remote
+WLED_GLOBAL bool notifyDirect _INIT(true);                        // send notification if change via UI or HTTP API
+WLED_GLOBAL bool notifyButton _INIT(true);                        // send if updated by button or infrared remote
 WLED_GLOBAL bool notifyAlexa  _INIT(false);                       // send notification if updated via Alexa
-WLED_GLOBAL bool notifyHue    _INIT(true);                        // send notification if Hue light changes
+WLED_GLOBAL bool notifyHue    _INIT(false);                       // send notification if Hue light changes
 #endif
 
 // effects


### PR DESCRIPTION
(Pull request to fix the broken Sync button, after previous discussions here: https://github.com/wled/WLED/pull/4810#issuecomment-3184782048)

Summary:

---

In the past, the "notify direct" flag controlled all network syncing, propagating all color changes to other devices on the network. Pressing the UI Sync button only toggled this flag, so "notify direct" was set to false by default.

In version 0.15, a separate "master" sync flag was introduced, and the UI Sync button now only activates this master flag. However, the rest of the flag defaults weren't configured to sync anything at all. As a result, users pressing Sync saw *no* syncing at all, leading to multiple bug reports.

Defaults are now user-friendly: Enabling Sync on a WLED device syncs all of *its* color changes, whether made via the UI, API or remote button, providing a consistent experience which matches the intended behavior from past WLED versions.

Philips Hue sync is now also disabled by default, making the stock defaults focused on WLED devices. Users with other RGB ecosystems can manually enable the Hue or Alexa syncing in the settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Behavior Changes
  - Notifications for UI/HTTP actions are now enabled by default.
  - Notifications for button/IR remote actions are now enabled by default.
  - Notifications for Hue Bridge changes are now disabled by default.
  - Applies to fresh installs/resets using default settings; existing custom configurations are unaffected.
  - Expect more immediate notifications during direct control, with quieter behavior for Hue-driven updates unless re-enabled in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->