### PR TITLE
Make version information consistent across update interfaces

### DIFF
--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -76,7 +76,7 @@
 		A huge thank you to everyone who helped me create WLED!<br><br>
 		(c) 2016-2024 Christian Schwinne <br>
 		<i>Licensed under the <a href="https://github.com/wled-dev/WLED/blob/main/LICENSE" target="_blank">EUPL v1.2 license</a></i><br><br>
-		Server message: <span class="sip"> Response error! </span><hr>
+		Installed version: <span class="sip">WLED ##VERSION##</span><hr>
 		<div id="toast"></div>
 		<button type="button" onclick="B()">Back</button><button type="submit">Save</button>
 	</form>

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -27,7 +27,7 @@
 <body onload="GetV()">
 	<h2>WLED Software Update</h2>
 	<form method='POST' action='./update' id='upd' enctype='multipart/form-data' onsubmit="toggle('upd')">
-		Installed version: <span class="sip">##VERSION##</span><br>
+		Installed version: <span class="sip">WLED ##VERSION##</span><br>
 		Download the latest binary: <a href="https://github.com/wled-dev/WLED/releases" target="_blank" 
 		style="vertical-align: text-bottom; display: inline-flex;">
 		<img src="https://img.shields.io/github/release/wled-dev/WLED.svg?style=flat-square"></a><br>

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -26,7 +26,8 @@ void XML_response(Print& dest)
   );
 }
 
-static void extractPin(Print& settingsScript, const JsonObject &obj, const char *key) {
+static void extractPin(Print& settingsScript, const JsonObject &obj, const char *key)
+{
   if (obj[key].is<JsonArray>()) {
     JsonArray pins = obj[key].as<JsonArray>();
     for (JsonVariant pv : pins) {
@@ -35,6 +36,22 @@ static void extractPin(Print& settingsScript, const JsonObject &obj, const char 
   } else {
     if (obj[key].as<int>() > -1) { settingsScript.print(","); settingsScript.print(obj[key].as<int>()); }
   }
+}
+
+void fillWLEDVersion(char *buf, size_t len)
+{
+  if (!buf || len == 0) return;
+
+  snprintf_P(buf,len,PSTR("WLED %s (%d)<br>\\\"%s\\\"<br>(Processor: %s)"),
+    versionString,
+    VERSION,
+    releaseString,
+  #if defined(ARDUINO_ARCH_ESP32)
+    ESP.getChipModel()
+  #else
+    "ESP8266"
+  #endif
+  );
 }
 
 // print used pins by scanning JsonObject (1 level deep)
@@ -72,7 +89,8 @@ static void fillUMPins(Print& settingsScript, const JsonObject &mods)
   }
 }
 
-void appendGPIOinfo(Print& settingsScript) {
+void appendGPIOinfo(Print& settingsScript)
+{
   settingsScript.print(F("d.um_p=[-1")); // has to have 1 element
   if (i2c_sda > -1 && i2c_scl > -1) {
     settingsScript.printf_P(PSTR(",%d,%d"), i2c_sda, i2c_scl);
@@ -594,7 +612,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormCheckbox(settingsScript,PSTR("AO"),aOtaEnabled);
     printSetFormCheckbox(settingsScript,PSTR("SU"),otaSameSubnet);
     char tmp_buf[128];
-    snprintf_P(tmp_buf,sizeof(tmp_buf),PSTR("WLED %s (build %d)"),versionString,VERSION);
+    fillWLEDVersion(tmp_buf,sizeof(tmp_buf));
     printSetClassElementHTML(settingsScript,PSTR("sip"),0,tmp_buf);
     settingsScript.printf_P(PSTR("sd=\"%s\";"), serverDescription);
     //hide settings if not compiled
@@ -656,16 +674,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
   if (subPage == SUBPAGE_UPDATE) // update
   {
     char tmp_buf[128];
-    snprintf_P(tmp_buf,sizeof(tmp_buf),PSTR("WLED %s<br>%s<br>(%s build %d)"),
-      versionString,
-      releaseString,
-    #if defined(ARDUINO_ARCH_ESP32)
-      ESP.getChipModel(),
-    #else
-      "esp8266",
-    #endif
-      VERSION);
-
+    fillWLEDVersion(tmp_buf,sizeof(tmp_buf));
     printSetClassElementHTML(settingsScript,PSTR("sip"),0,tmp_buf);
     #ifndef ARDUINO_ARCH_ESP32
     settingsScript.print(F("toggle('rev');"));  // hide revert button on ESP8266


### PR DESCRIPTION
The duplication of logic and the formatting differences between the "OTA Updates" and "Security & Updates" pages made it very difficult to find the exact version details.

With this change, both update-pages now share the same consistent and detailed formatting, making it easy for users to identify which exact version and binary of WLED they've installed.

The version format has also been improved to make it much easier to understand.

---

## OTA Update Page (only reachable via Info -> OTA Update):

Before:

![ota-before](https://github.com/user-attachments/assets/cb5f068f-7e0e-45d0-97d9-b1aef617204d)

After:

![ota-after](https://github.com/user-attachments/assets/6523fad2-7924-4c10-a11b-722ce0828486)


## Security & Updates Page:

Before (doesn't say anything useful):

![upd-before](https://github.com/user-attachments/assets/f1251a0e-8ad8-4993-9e68-6ff208b5215b)

After:

![upd-after](https://github.com/user-attachments/assets/251a1820-40aa-45e2-8b15-4ff87ff93ff1)

---

The new format is easier for users to understand, and only adds 10 characters. Most builds hover around 75 characters total, and I've verified that the 128 byte buffer would fit extremely long `WLED_RELEASE_NAME` names. Much, much longer than any person would ever use. :)

With these changes, it's finally easy to find the vital information about the installed build. I didn't even know that it was possible to find it in the UI until I started digging around in the code and found that it was hiding on the well-hidden OTA page, hehe. It makes sense to have it on the Security & Updates page too.

I also fixed the braces of two functions that weren't consistent with the coding style of the rest of that file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved version display across the app. The About and Update pages now show “Installed version: WLED <version>” for clarity.
  - Added a richer version details section that includes the version, build number, release name, and processor model, presented consistently across relevant UI sections.
  - Replaced a previous generic server error line in the About section with the installed version information for a more informative and user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->