### PR TITLE
Fix bootloop if config is reset

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -787,13 +787,16 @@ bool verifyConfig() {
 }
 
 // rename config file and reboot
+// if the file doesn't exist, such as after a reset, do nothing
 void resetConfig() {
-  DEBUG_PRINTLN(F("Reset config"));
-  char backupname[32];
-  strcpy(backupname, s_cfg_json);
-  strcat(backupname, ".rst.json");
-  WLED_FS.rename(s_cfg_json, backupname);
-  doReboot = true;
+  if (WLED_FS.exists(s_cfg_json)) {
+    DEBUG_PRINTLN(F("Reset config"));
+    char backupname[32];
+    strcpy(backupname, s_cfg_json);
+    strcat(backupname, ".rst.json");
+    WLED_FS.rename(s_cfg_json, backupname);
+    doReboot = true;
+  }
 }
 
 bool deserializeConfigFromFS() {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -787,13 +787,12 @@ bool verifyConfig() {
 }
 
 // rename config file and reboot
-// if the file doesn't exist, such as after a reset, do nothing
+// if the cfg file doesn't exist, such as after a reset, do nothing
 void resetConfig() {
   if (WLED_FS.exists(s_cfg_json)) {
     DEBUG_PRINTLN(F("Reset config"));
     char backupname[32];
-    strcpy(backupname, s_cfg_json);
-    strcat(backupname, ".rst.json");
+    snprintf_P(backupname, sizeof(backupname), PSTR("/rst.%s"), &s_cfg_json[1]);
     WLED_FS.rename(s_cfg_json, backupname);
     doReboot = true;
   }

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -515,7 +515,7 @@ bool compareFiles(const char* path1, const char* path2) {
   return identical;
 }
 
-static const char s_backup_json[] PROGMEM = "/bkp.";
+static const char s_backup_fmt[] PROGMEM = "/bkp.%s";
 
 bool backupFile(const char* filename) {
   DEBUG_PRINTF("backup %s \n", filename);
@@ -524,7 +524,7 @@ bool backupFile(const char* filename) {
     return false;
   }
   char backupname[32];
-  snprintf(backupname, sizeof(backupname), "%s%s", s_backup_json, filename + 1); // skip leading '/' in filename
+  snprintf_P(backupname, sizeof(backupname), s_backup_fmt, filename + 1); // skip leading '/' in filename
 
   if (copyFile(filename, backupname)) {
     DEBUG_PRINTLN(F("backup ok"));
@@ -537,7 +537,7 @@ bool backupFile(const char* filename) {
 bool restoreFile(const char* filename) {
   DEBUG_PRINTF("restore %s \n", filename);
   char backupname[32];
-  snprintf(backupname, sizeof(backupname), "%s%s", s_backup_json, filename + 1); // skip leading '/' in filename
+  snprintf_P(backupname, sizeof(backupname), s_backup_fmt, filename + 1); // skip leading '/' in filename
 
   if (!WLED_FS.exists(backupname)) {
     DEBUG_PRINTLN(F("no backup found"));
@@ -565,9 +565,9 @@ bool validateJsonFile(const char* filename) {
   bool result = deserializeJson(doc, file, DeserializationOption::Filter(filter)) == DeserializationError::Ok;
   file.close();
   if (!result) {
-    DEBUG_PRINTF("Invalid JSON file %s\n", filename);
+    DEBUG_PRINTF_P(PSTR("Invalid JSON file %s\n"), filename);
   } else {
-    DEBUG_PRINTF("Valid JSON file %s\n", filename);
+    DEBUG_PRINTF_P(PSTR("Valid JSON file %s\n"), filename);
   }
   return result;
 }

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -721,8 +721,8 @@ void *realloc_malloc(void *ptr, size_t size) {
 // if a bootloop is detected: restore settings from backup, then reset settings, then switch boot image (and repeat)
 
 #define BOOTLOOP_THRESHOLD      5     // number of consecutive crashes to trigger bootloop detection
-#define BOOTLOOP_ACTION_RESTORE 0     // default action: restore config from /cfg.bak
-#define BOOTLOOP_ACTION_RESET   1     // if restore does not work, reset config (rename /cfg.json to /cfg.fault)
+#define BOOTLOOP_ACTION_RESTORE 0     // default action: restore config from /bak.cfg.json
+#define BOOTLOOP_ACTION_RESET   1     // if restore does not work, reset config (rename /cfg.json to /rst.cfg.json)
 #define BOOTLOOP_ACTION_OTA     2     // swap the boot partition
 #define BOOTLOOP_ACTION_DUMP    3     // nothing seems to help, dump files to serial and reboot (until hardware reset)
 #ifdef ESP8266

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -836,6 +836,9 @@ void handleBootLoop() {
   #endif
   else
     dumpFilesToSerial();
+#ifdef ESP8266
+  ESP.rtcUserMemoryWrite(ACTIONT_TRACKER_IDX, &bl_actiontracker, sizeof(uint32_t));
+#endif
   ESP.restart(); // restart cleanly and don't wait for another crash
 }
 


### PR DESCRIPTION
A couple of small fixes for #4793:

- If the config was missing, the device will bootloop, because `validConfig()` returns false every time.  Fix this by disabling the reboot in `resetConfig()` if we already had no config.
- Fix a minor bug on ESP8266 with saving the action state.

This is the most likely cause of #4848 - once an invalid config is reset, the device is stuck in a bootloop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration reset now verifies a config file exists before proceeding, preventing unnecessary backup steps and avoiding unintended reboots when no file is present.

* **Improvements**
  * ESP8266 devices: Boot-loop recovery better preserves recovery state across restarts, reducing repeated boot loops.
  * Backups now validate configuration files before creating backups, avoiding backups of invalid files.

* **Chores**
  * Minor internal comments added (no user action required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->