### PR TITLE
new usermod hooks "onUdpPacket"

### DIFF
--- a/usermods/udp_name_sync/library.json
+++ b/usermods/udp_name_sync/library.json
@@ -1,0 +1,5 @@
+{
+  "name": "udp_name_sync",
+  "build": { "libArchive": false },
+  "dependencies": {}
+}

--- a/usermods/udp_name_sync/udp_name_sync.cpp
+++ b/usermods/udp_name_sync/udp_name_sync.cpp
@@ -45,15 +45,16 @@ class UdpNameSync : public Usermod {
 	return;
       }
 
-      if (0 == strcmp(mainseg.name, segmentName)) return; //same name, do nothing
+      const char* curName = mainseg.name ? mainseg.name : "";
+      if (strcmp(curName, segmentName) == 0) return; // same name, do nothing
 
       notifierUdp.beginPacket(broadcastIp, udpPort);
       DEBUG_PRINT(F("UdpNameSync: saving segment name "));
       DEBUG_PRINTLN(mainseg.name);
-      byte length = strlen(mainseg.name);
-      strlcpy(segmentName, mainseg.name, length+1);
-      strlcpy((char *)&udpOut[1], segmentName, length+1);
-      notifierUdp.write(udpOut, length + 2);
+      size_t length = strlen(mainseg.name);
+      strlcpy(segmentName, mainseg.name, sizeof(segmentName));
+      strlcpy((char *)&udpOut[1], segmentName, sizeof(udpOut) - 1); // leave room for header byte
+      notifierUdp.write(udpOut, 2 + strnlen((char *)&udpOut[1], sizeof(udpOut) - 1));
       notifierUdp.endPacket();
       DEBUG_PRINT(F("UdpNameSync: Sent segment name : "));
       DEBUG_PRINTLN(segmentName);

--- a/usermods/udp_name_sync/udp_name_sync.cpp
+++ b/usermods/udp_name_sync/udp_name_sync.cpp
@@ -46,13 +46,8 @@ class UdpNameSync : public Usermod {
         return;
       }
 
-      char checksumSegName = 0;
-      char checksumCurName = 0;
-      for(int i=0; i++; mainseg.name[i]==0 || segmentName[i]==0) {
-	checksumSegName+=segmentName[i];
-	checksumCurName+=mainseg.name[i];
-      }
-      if (checksumCurName == checksumSegName) return; // same name, do nothing
+      const char* curName = mainseg.name ? mainseg.name : "";
+      if (strncmp(curName, segmentName, sizeof(segmentName)) == 0) return; // same name, do nothing
 
       notifierUdp.beginPacket(broadcastIp, udpPort);
       DEBUG_PRINT(F("UdpNameSync: saving segment name "));

--- a/usermods/udp_name_sync/udp_name_sync.cpp
+++ b/usermods/udp_name_sync/udp_name_sync.cpp
@@ -36,13 +36,14 @@ class UdpNameSync : public Usermod {
       byte udpOut[WLED_MAX_SEGNAME_LEN + 2];
       udpOut[0] = 2; // 0: wled notifier protocol, 1: warls protocol, 2 is free
       
-      if (strlen(segmentName) && !mainseg.name) { //name is back to null
-	notifierUdp.beginPacket(broadcastIp, udpPort);
-	strcpy(segmentName,"");
-	DEBUG_PRINTLN(F("UdpNameSync: sending Null name"));
-	notifierUdp.write( udpOut , 2);
-	notifierUdp.endPacket();
-	return;
+      if (strlen(segmentName) && !mainseg.name) { // name cleared
+        notifierUdp.beginPacket(broadcastIp, udpPort);
+        segmentName[0] = '\0';
+        DEBUG_PRINTLN(F("UdpNameSync: sending empty name"));
+        udpOut[1] = 0; // explicit empty string
+        notifierUdp.write(udpOut, 2);
+        notifierUdp.endPacket();
+        return;
       }
 
       const char* curName = mainseg.name ? mainseg.name : "";

--- a/usermods/udp_name_sync/udp_name_sync.cpp
+++ b/usermods/udp_name_sync/udp_name_sync.cpp
@@ -1,0 +1,79 @@
+#include "wled.h"
+
+class UdpNameSync : public Usermod {
+
+  private:
+
+    bool enabled = false;
+    bool initDone = false;
+    unsigned long lastTime = 0;
+    char segmentName[WLED_MAX_SEGNAME_LEN] = {0};
+    static const char _name[];
+    static const char _enabled[];
+
+  public:
+    /**
+     * Enable/Disable the usermod
+     */
+    inline void enable(bool enable) { enabled = enable; }
+
+    /**
+     * Get usermod enabled/disabled state
+     */
+    inline bool isEnabled() { return enabled; }
+
+    void setup() override {
+      initDone = true;
+    }
+
+    void loop() override {
+      if (!WLED_CONNECTED) return;
+      if (!udpConnected) return;
+      Segment& mainseg = strip.getMainSegment();
+      if (!strlen(segmentName) && !mainseg.name) return; //name was never set, do nothing
+
+      IPAddress broadcastIp = ~uint32_t(Network.subnetMask()) | uint32_t(Network.gatewayIP());
+      byte udpOut[WLED_MAX_SEGNAME_LEN + 2];
+      udpOut[0] = 2; // 0: wled notifier protocol, 1: warls protocol, 2 is free
+      
+      if (strlen(segmentName) && !mainseg.name) { //name is back to null
+	notifierUdp.beginPacket(broadcastIp, udpPort);
+	strcpy(segmentName,"");
+	DEBUG_PRINTLN(F("UdpNameSync: sending Null name"));
+	notifierUdp.write( udpOut , 2);
+	notifierUdp.endPacket();
+	return;
+      }
+
+      if (0 == strcmp(mainseg.name, segmentName)) return; //same name, do nothing
+
+      notifierUdp.beginPacket(broadcastIp, udpPort);
+      DEBUG_PRINT(F("UdpNameSync: saving segment name "));
+      DEBUG_PRINTLN(mainseg.name);
+      byte length = strlen(mainseg.name);
+      strlcpy(segmentName, mainseg.name, length+1);
+      strlcpy((char *)&udpOut[1], segmentName, length+1);
+      notifierUdp.write(udpOut, length + 2);
+      notifierUdp.endPacket();
+      DEBUG_PRINT(F("UdpNameSync: Sent segment name : "));
+      DEBUG_PRINTLN(segmentName);
+    }
+
+    bool onUdpPacket(uint8_t * payload, uint8_t len) override {
+      DEBUG_PRINT(F("UdpNameSync: Received packet"));
+      if (payload[0] != 2) return false;
+      //else
+      Segment& mainseg = strip.getMainSegment();
+      mainseg.setName((char *)&payload[1]);
+      DEBUG_PRINT(F("UdpNameSync: set segment name"));
+      return true;
+    }
+};
+
+
+// add more strings here to reduce flash memory usage
+const char UdpNameSync::_name[]    PROGMEM = "UdpNameSync";
+const char UdpNameSync::_enabled[] PROGMEM = "enabled";
+
+static UdpNameSync udp_name_sync;
+REGISTER_USERMOD(udp_name_sync);

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -442,6 +442,7 @@ class Usermod {
     virtual void onMqttConnect(bool sessionPresent) {}                       // fired when MQTT connection is established (so usermod can subscribe)
     virtual bool onMqttMessage(char* topic, char* payload) { return false; } // fired upon MQTT message received (wled topic)
     virtual bool onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t len) { return false; } // fired upon ESP-NOW message received
+    virtual bool onUdpPacket(uint8_t* payload, uint8_t len) { return false; } //fired upon UDP packet received
     virtual void onUpdateBegin(bool) {}                                      // fired prior to and after unsuccessful firmware update
     virtual void onStateChange(uint8_t mode) {}                              // fired upon WLED state change
     virtual uint16_t getId() {return USERMOD_ID_UNSPECIFIED;}
@@ -481,6 +482,7 @@ namespace UsermodManager {
 #ifndef WLED_DISABLE_ESPNOW
   bool onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t len);
 #endif
+  bool onUdpPacket(uint8_t* payload, uint8_t len);
   void onUpdateBegin(bool);
   void onStateChange(uint8_t);
   Usermod* lookup(uint16_t mod_id);

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -442,7 +442,7 @@ class Usermod {
     virtual void onMqttConnect(bool sessionPresent) {}                       // fired when MQTT connection is established (so usermod can subscribe)
     virtual bool onMqttMessage(char* topic, char* payload) { return false; } // fired upon MQTT message received (wled topic)
     virtual bool onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t len) { return false; } // fired upon ESP-NOW message received
-    virtual bool onUdpPacket(uint8_t* payload, uint8_t len) { return false; } //fired upon UDP packet received
+    virtual bool onUdpPacket(uint8_t* payload, size_t len) { return false; } //fired upon UDP packet received
     virtual void onUpdateBegin(bool) {}                                      // fired prior to and after unsuccessful firmware update
     virtual void onStateChange(uint8_t mode) {}                              // fired upon WLED state change
     virtual uint16_t getId() {return USERMOD_ID_UNSPECIFIED;}
@@ -482,7 +482,7 @@ namespace UsermodManager {
 #ifndef WLED_DISABLE_ESPNOW
   bool onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t len);
 #endif
-  bool onUdpPacket(uint8_t* payload, uint8_t len);
+  bool onUdpPacket(uint8_t* payload, size_t len);
   void onUpdateBegin(bool);
   void onStateChange(uint8_t);
   Usermod* lookup(uint16_t mod_id);

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -572,7 +572,7 @@ void handleNotifications()
       //if the number of LEDs in your installation doesn't allow that, please include padding bytes at the end of the last packet
       byte tpmType = udpIn[1];
       if (tpmType == 0xaa) { //TPM2.NET polling, expect answer
-	sendTPM2Ack(); return;
+        sendTPM2Ack(); return;
       }
       if (tpmType != 0xda) return; //return if notTPM2.NET data
 
@@ -588,12 +588,12 @@ void handleNotifications()
       unsigned id = (tpmPayloadFrameSize/3)*(packetNum-1); //start LED
       unsigned totalLen = strip.getLengthTotal();
       for (size_t i = 6; i < tpmPayloadFrameSize + 4U && id < totalLen; i += 3, id++) {
-	setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
       }
       if (tpmPacketCount == numPackets) { //reset packet count and show if all packets were received
-	tpmPacketCount = 0;
-	if (useMainSegmentOnly) strip.trigger();
-	else                    strip.show();
+        tpmPacketCount = 0;
+        if (useMainSegmentOnly) strip.trigger();
+        else                    strip.show();
       }
       return;
     }
@@ -605,37 +605,37 @@ void handleNotifications()
       if (packetSize < 2) return;
 
       if (udpIn[1] == 0) {
-	realtimeTimeout = 0; // cancel realtime mode immediately
-	return;
+        realtimeTimeout = 0; // cancel realtime mode immediately
+        return;
       } else {
-	realtimeLock(udpIn[1]*1000 +1, REALTIME_MODE_UDP);
+        realtimeLock(udpIn[1]*1000 +1, REALTIME_MODE_UDP);
       }
       if (realtimeOverride) return;
 
       unsigned totalLen = strip.getLengthTotal();
       if (udpIn[0] == 1 && packetSize > 5) { //warls
-	for (size_t i = 2; i < packetSize -3; i += 4) {
-	  setRealtimePixel(udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3], 0);
-	}
+        for (size_t i = 2; i < packetSize -3; i += 4) {
+          setRealtimePixel(udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3], 0);
+        }
       } else if (udpIn[0] == 2 && packetSize > 4) { //drgb
-	for (size_t i = 2, id = 0; i < packetSize -2 && id < totalLen; i += 3, id++)
-	  {
-	    setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-	  }
+        for (size_t i = 2, id = 0; i < packetSize -2 && id < totalLen; i += 3, id++)
+          {
+            setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+          }
       } else if (udpIn[0] == 3 && packetSize > 6) { //drgbw
-	  for (size_t i = 2, id = 0; i < packetSize -3 && id < totalLen; i += 4, id++) {
-	    setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
-	  }
+          for (size_t i = 2, id = 0; i < packetSize -3 && id < totalLen; i += 4, id++) {
+            setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
+          }
       } else if (udpIn[0] == 4 && packetSize > 7) { //dnrgb
-	unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-	for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 3, id++) {
-	  setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-	}
+        unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
+        for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 3, id++) {
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+        }
       } else if (udpIn[0] == 5 && packetSize > 8) { //dnrgbw
-	unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-	for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 4, id++) {
-	  setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
-	}
+        unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
+        for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 4, id++) {
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
+        }
       }
       if (useMainSegmentOnly) strip.trigger();
       else                    strip.show();

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -557,6 +557,9 @@ void handleNotifications()
     return;
   }
 
+  // usermods hook can override processing
+  if (UsermodManager::onUdpPacket(udpIn, packetSize)) return;
+
   //wled notifier, ignore if realtime packets active
   if (udpIn[0] == 0 && !realtimeMode && receiveGroups)
   {

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -557,9 +557,6 @@ void handleNotifications()
     return;
   }
 
-  // usermods hook can override processing
-  if (UsermodManager::onUdpPacket(udpIn, packetSize)) return;
-
   //wled notifier, ignore if realtime packets active
   if (udpIn[0] == 0 && !realtimeMode && receiveGroups)
   {
@@ -568,93 +565,82 @@ void handleNotifications()
     return;
   }
 
-  if (!receiveDirect) return;
+  if (receiveDirect) {
+    //TPM2.NET
+    if (udpIn[0] == 0x9c) {
+      //WARNING: this code assumes that the final TMP2.NET payload is evenly distributed if using multiple packets (ie. frame size is constant)
+      //if the number of LEDs in your installation doesn't allow that, please include padding bytes at the end of the last packet
+      byte tpmType = udpIn[1];
+      if (tpmType == 0xaa) { //TPM2.NET polling, expect answer
+	sendTPM2Ack(); return;
+      }
+      if (tpmType != 0xda) return; //return if notTPM2.NET data
 
-  //TPM2.NET
-  if (udpIn[0] == 0x9c)
-  {
-    //WARNING: this code assumes that the final TMP2.NET payload is evenly distributed if using multiple packets (ie. frame size is constant)
-    //if the number of LEDs in your installation doesn't allow that, please include padding bytes at the end of the last packet
-    byte tpmType = udpIn[1];
-    if (tpmType == 0xaa) { //TPM2.NET polling, expect answer
-      sendTPM2Ack(); return;
+      realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
+      realtimeLock(realtimeTimeoutMs, REALTIME_MODE_TPM2NET);
+      if (realtimeOverride) return;
+
+      tpmPacketCount++; //increment the packet count
+      if (tpmPacketCount == 1) tpmPayloadFrameSize = (udpIn[2] << 8) + udpIn[3]; //save frame size for the whole payload if this is the first packet
+      byte packetNum = udpIn[4]; //starts with 1!
+      byte numPackets = udpIn[5];
+
+      unsigned id = (tpmPayloadFrameSize/3)*(packetNum-1); //start LED
+      unsigned totalLen = strip.getLengthTotal();
+      for (size_t i = 6; i < tpmPayloadFrameSize + 4U && id < totalLen; i += 3, id++) {
+	setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+      }
+      if (tpmPacketCount == numPackets) { //reset packet count and show if all packets were received
+	tpmPacketCount = 0;
+	if (useMainSegmentOnly) strip.trigger();
+	else                    strip.show();
+      }
+      return;
     }
-    if (tpmType != 0xda) return; //return if notTPM2.NET data
 
-    realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
-    realtimeLock(realtimeTimeoutMs, REALTIME_MODE_TPM2NET);
-    if (realtimeOverride) return;
+    //UDP realtime: 1 warls 2 drgb 3 drgbw 4 dnrgb 5 dnrgbw
+    if (udpIn[0] > 0 && udpIn[0] < 6) {
+      realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
+      DEBUG_PRINTLN(realtimeIP);
+      if (packetSize < 2) return;
 
-    tpmPacketCount++; //increment the packet count
-    if (tpmPacketCount == 1) tpmPayloadFrameSize = (udpIn[2] << 8) + udpIn[3]; //save frame size for the whole payload if this is the first packet
-    byte packetNum = udpIn[4]; //starts with 1!
-    byte numPackets = udpIn[5];
+      if (udpIn[1] == 0) {
+	realtimeTimeout = 0; // cancel realtime mode immediately
+	return;
+      } else {
+	realtimeLock(udpIn[1]*1000 +1, REALTIME_MODE_UDP);
+      }
+      if (realtimeOverride) return;
 
-    unsigned id = (tpmPayloadFrameSize/3)*(packetNum-1); //start LED
-    unsigned totalLen = strip.getLengthTotal();
-    for (size_t i = 6; i < tpmPayloadFrameSize + 4U && id < totalLen; i += 3, id++) {
-      setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-    }
-    if (tpmPacketCount == numPackets) { //reset packet count and show if all packets were received
-      tpmPacketCount = 0;
+      unsigned totalLen = strip.getLengthTotal();
+      if (udpIn[0] == 1 && packetSize > 5) { //warls
+	for (size_t i = 2; i < packetSize -3; i += 4) {
+	  setRealtimePixel(udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3], 0);
+	}
+      } else if (udpIn[0] == 2 && packetSize > 4) { //drgb
+	for (size_t i = 2, id = 0; i < packetSize -2 && id < totalLen; i += 3, id++)
+	  {
+	    setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+	  }
+      } else if (udpIn[0] == 3 && packetSize > 6) { //drgbw
+	  for (size_t i = 2, id = 0; i < packetSize -3 && id < totalLen; i += 4, id++) {
+	    setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
+	  }
+      } else if (udpIn[0] == 4 && packetSize > 7) { //dnrgb
+	unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
+	for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 3, id++) {
+	  setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+	}
+      } else if (udpIn[0] == 5 && packetSize > 8) { //dnrgbw
+	unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
+	for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 4, id++) {
+	  setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
+	}
+      }
       if (useMainSegmentOnly) strip.trigger();
       else                    strip.show();
-    }
-    return;
-  }
-
-  //UDP realtime: 1 warls 2 drgb 3 drgbw 4 dnrgb 5 dnrgbw
-  if (udpIn[0] > 0 && udpIn[0] < 6)
-  {
-    realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
-    DEBUG_PRINTLN(realtimeIP);
-    if (packetSize < 2) return;
-
-    if (udpIn[1] == 0) {
-      realtimeTimeout = 0; // cancel realtime mode immediately
       return;
-    } else {
-      realtimeLock(udpIn[1]*1000 +1, REALTIME_MODE_UDP);
     }
-    if (realtimeOverride) return;
-
-    unsigned totalLen = strip.getLengthTotal();
-    if (udpIn[0] == 1 && packetSize > 5) //warls
-    {
-      for (size_t i = 2; i < packetSize -3; i += 4)
-      {
-        setRealtimePixel(udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3], 0);
-      }
-    } else if (udpIn[0] == 2 && packetSize > 4) //drgb
-    {
-      for (size_t i = 2, id = 0; i < packetSize -2 && id < totalLen; i += 3, id++)
-      {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-      }
-    } else if (udpIn[0] == 3 && packetSize > 6) //drgbw
-    {
-      for (size_t i = 2, id = 0; i < packetSize -3 && id < totalLen; i += 4, id++)
-      {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
-      }
-    } else if (udpIn[0] == 4 && packetSize > 7) //dnrgb
-    {
-      unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-      for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 3, id++)
-      {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-      }
-    } else if (udpIn[0] == 5 && packetSize > 8) //dnrgbw
-    {
-      unsigned id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-      for (size_t i = 4; i < packetSize -2 && id < totalLen; i += 4, id++)
-      {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
-      }
-    }
-    if (useMainSegmentOnly) strip.trigger();
-    else                    strip.show();
-    return;
   }
 
   // API over UDP
@@ -672,6 +658,8 @@ void handleNotifications()
     }
     releaseJSONBufferLock();
   }
+
+  UsermodManager::onUdpPacket(udpIn, packetSize);
 }
 
 

--- a/wled00/um_manager.cpp
+++ b/wled00/um_manager.cpp
@@ -68,7 +68,7 @@ bool UsermodManager::onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t 
   return false;
 }
 #endif
-bool UsermodManager::onUdpPacket(uint8_t* payload, uint8_t len) {
+bool UsermodManager::onUdpPacket(uint8_t* payload, size_t len) {
   for (auto mod = _usermod_table_begin; mod < _usermod_table_end; ++mod) if ((*mod)->onUdpPacket(payload, len)) return true;
   return false;
 }

--- a/wled00/um_manager.cpp
+++ b/wled00/um_manager.cpp
@@ -68,6 +68,10 @@ bool UsermodManager::onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t 
   return false;
 }
 #endif
+bool UsermodManager::onUdpPacket(uint8_t* payload, uint8_t len) {
+  for (auto mod = _usermod_table_begin; mod < _usermod_table_end; ++mod) if ((*mod)->onUdpPacket(payload, len)) return true;
+  return false;
+}
 void UsermodManager::onUpdateBegin(bool init) { for (auto mod = _usermod_table_begin; mod < _usermod_table_end; ++mod) (*mod)->onUpdateBegin(init); } // notify usermods that update is to begin
 void UsermodManager::onStateChange(uint8_t mode) { for (auto mod = _usermod_table_begin; mod < _usermod_table_end; ++mod) (*mod)->onStateChange(mode); } // notify usermods that WLED state changed
 


### PR DESCRIPTION
this new hooks will help you implement new and custom protocols in usermods.
I've provided an example (see usermods/udp_name_sync). The example will help you share the main segment name across different WLED instances.
The segment name can be useful to sync with some effects like GIF image or scrolling text.

If you define new packet format in your usermod, make sure it will either not collide with already used version of wled udp packet :
- 0 is for udp sync
- 1 is for AudioReactive data
- 2 is for udp_name_sync :)

Also, the onUdpPacket will override "parseNotification" if it returns "true". Have fun!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UDP Name Sync: devices broadcast and receive main segment name changes for network-wide name consistency.
  * Usermod UDP hook: usermods can observe and handle incoming UDP packets for custom integrations.

* **Behavior Change**
  * Real-time and TPM2.NET UDP processing now respect the "direct receive" setting; the UDP hook is invoked after core UDP handling.

* **Chores**
  * Added library manifest for the UDP Name Sync component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->