### PR TITLE
Fix operation of length 1 strips, such as PWM LEDs

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1340,11 +1340,6 @@ void WS2812FX::blendSegment(const Segment &topSegment) const {
   uint8_t       opacity    = topSegment.currentBri(); // returns transitioned opacity for style FADE
   uint8_t       cct        = topSegment.currentCCT();
 
-  if (length == 1) {
-    // Can't blend only a single pixel, prevents crash when bus init fails
-    return;
-  }
-
   Segment::setClippingRect(0, 0);             // disable clipping by default
 
   const unsigned dw = (blendingStyle==BLEND_STYLE_OUTSIDE_IN ? progInv : progress) * width / 0xFFFFU + 1;


### PR DESCRIPTION
Revert e5ba97b because it disables all length 1 segments, commonly used for PWM outputs.  Segments of length 1 are valid and expected under many conditions.

This fixes the output issues reported by @naster_mick on Discord and @qistoph in #4782.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blending behavior for single-pixel segments, ensuring they are included in standard blending instead of being skipped.
  * Ensures 1x1 segments use fade-based blending for consistent visual transitions.
  * Improves visual consistency and smoother fades across all segment sizes.
* **Chores**
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->