### PR TITLE
fix ancient UI bug that hides the speed slider in percent FX

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3940,7 +3940,7 @@ uint16_t mode_percent(void) {
 
  	return FRAMETIME;
 }
-static const char _data_FX_MODE_PERCENT[] PROGMEM = "Percent@,% of fill,,,,One color;!,!;!";
+static const char _data_FX_MODE_PERCENT[] PROGMEM = "Percent@!,% of fill,,,,One color;!,!;!";
 
 
 /*


### PR DESCRIPTION
percent FX has transition speed built in, it was just hidden for years...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metadata for the “Percent” effect to correct parameter ordering and visibility in the UI.
  * Ensures controls display consistently across supported controllers/apps, preventing hidden or misplaced parameters.
  * No changes to effect behavior or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->