### PR TITLE
fix ancient UI bug that hides the speed slider in percent FX 0.15 edition

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3913,7 +3913,7 @@ uint16_t mode_percent(void) {
 
  	return FRAMETIME;
 }
-static const char _data_FX_MODE_PERCENT[] PROGMEM = "Percent@,% of fill,,,,One color;!,!;!";
+static const char _data_FX_MODE_PERCENT[] PROGMEM = "Percent@!,% of fill,,,,One color;!,!;!";
 
 
 /*


### PR DESCRIPTION
percent FX has transition speed built in, it was just hidden for years...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ESP32 V4 build variant and optional parallel I2S output toggle in LED settings.
  - Enabled DMX input on ESP32 (IDF4 environments).
- Improvements
  - Smoother effect timing (up to 250 FPS, unlimited option), more reliable ESP-NOW remote handling, and better memory/board compatibility (ESP32 S2/S3/C3).
  - UI tweaks: pointer-based tooltips, clearer segment controls, palette button visibility, and installed version display.
- Bug Fixes
  - More consistent primary color handling across buttons, MQTT, Hue, and UI.
  - Stabilized audioreactive peak reset and preset application.
- Documentation
  - CHANGELOG updates; rotary encoder usermod notes refreshed.
- Chores
  - Automated release changelog; logs directory ignored; version bumped to 0.15.2-beta1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->