### PR TITLE
Bugfix for FX: Tri Fade

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1714,8 +1714,8 @@ static const char _data_FX_MODE_TRICOLOR_WIPE[] PROGMEM = "Tri Wipe@!;1,2,3;!";
  * Modified by Aircoookie
  */
 uint16_t mode_tricolor_fade(void) {
-  unsigned counter = strip.now * ((SEGMENT.speed >> 3) +1);
-  uint16_t prog = (counter * 768) >> 16;
+  uint16_t counter = strip.now * ((SEGMENT.speed >> 3) +1);
+  uint32_t prog = (counter * 768) >> 16;
 
   uint32_t color1 = 0, color2 = 0;
   unsigned stage = 0;


### PR DESCRIPTION
- incorrectly calculated counter and progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in the Tricolor Fade effect to prevent intermediate calculation overflow, resulting in smoother color transitions during long-running animations and high counter values.
  * Reduces potential visual artifacts without altering user settings or overall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->