### PR TITLE
issue #4920 add code to respect the NOWIFISLEEP build flag

### DIFF
--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -377,7 +377,9 @@ WLED_GLOBAL int8_t selectedWiFi  _INIT(0);
 WLED_GLOBAL byte apChannel       _INIT(1);                        // 2.4GHz WiFi AP channel (1-13)
 WLED_GLOBAL byte apHide          _INIT(0);                        // hidden AP SSID
 WLED_GLOBAL byte apBehavior      _INIT(AP_BEHAVIOR_BOOT_NO_CONN); // access point opens when no connection after boot by default
-  #ifdef ARDUINO_ARCH_ESP32
+  #ifdef NOWIFISLEEP
+WLED_GLOBAL bool noWifiSleep _INIT(NOWIFISLEEP);                  // honor build flag
+  #elif defined(ARDUINO_ARCH_ESP32)
 WLED_GLOBAL bool noWifiSleep _INIT(true);                         // disabling modem sleep modes will increase heat output and power usage, but may help with connection issues
   #else
 WLED_GLOBAL bool noWifiSleep _INIT(false);


### PR DESCRIPTION
added check to respect the build flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional build-time flag to control Wi‑Fi sleep behavior.
  * When provided, firmware uses the flag’s value; otherwise, platform defaults are applied (no change to standard builds).
  * Default behaviors remain: ESP32 builds default to Wi‑Fi sleep on; others off, unless the flag is set.
  * Applies to all supported boards; runtime settings and saved configurations are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->