### PR TITLE
Fix typo changable > changeable

### DIFF
--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -48,7 +48,7 @@
 		To enable OTA, for security reasons you need to also enter the correct password!<br>
 		The password should be changed when OTA is enabled.<br>
 		<b>Disable OTA when not in use, otherwise an attacker can reflash device software!</b><br>
-		<i>Settings on this page are only changable if OTA lock is disabled!</i><br>
+		<i>Settings on this page are only changeable if OTA lock is disabled!</i><br>
 		Deny access to WiFi settings if locked: <input type="checkbox" name="OW"><br><br>
 		Factory reset: <input type="checkbox" name="RS"><br>
 		All settings and presets will be erased.<br><br>


### PR DESCRIPTION
Fix typo that I discovered while tinkering in Wled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in the OTA lock description within the Security settings, changing “changable” to “changeable.”
  * Text-only update; no functional changes or impact on existing configurations or workflows.
  * Improves clarity and polish in user-facing copy.
  * Visible wherever the OTA lock guidance is shown in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->