### PR TITLE
Bugfix for gif player WRT inactive segment and bugfix in copy FX

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -135,7 +135,8 @@ uint16_t mode_copy_segment(void) {
     SEGMENT.fadeToBlackBy(5); // fade out
     return FRAMETIME;
   }
-  Segment sourcesegment = strip.getSegment(sourceid);
+  Segment& sourcesegment = strip.getSegment(sourceid);
+
   if (sourcesegment.isActive()) {
     uint32_t sourcecolor;
     uint32_t destcolor;

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -625,6 +625,9 @@ class Segment {
       DEBUGFX_PRINTLN();
       #endif
       clearName();
+      #ifdef WLED_ENABLE_GIF
+      endImagePlayback(this);
+      #endif
       deallocateData();
       p_free(pixels);
     }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -448,6 +448,9 @@ void Segment::setGeometry(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, ui
 
   // apply change immediately
   if (i2 <= i1) { //disable segment
+    #ifdef WLED_ENABLE_GIF
+    endImagePlayback(this);
+    #endif
     deallocateData();
     p_free(pixels);
     pixels = nullptr;
@@ -466,6 +469,9 @@ void Segment::setGeometry(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, ui
   #endif
   // safety check
   if (start >= stop || startY >= stopY) {
+    #ifdef WLED_ENABLE_GIF
+    endImagePlayback(this);
+    #endif
     deallocateData();
     p_free(pixels);
     pixels = nullptr;
@@ -479,6 +485,9 @@ void Segment::setGeometry(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, ui
     pixels = static_cast<uint32_t*>(allocate_buffer(length() * sizeof(uint32_t), BFRALLOC_PREFER_PSRAM | BFRALLOC_NOBYTEACCESS));
     if (!pixels) {
       DEBUGFX_PRINTLN(F("!!! Not enough RAM for pixel buffer !!!"));
+      #ifdef WLED_ENABLE_GIF
+      endImagePlayback(this);
+      #endif
       deallocateData();
       errorFlag = ERR_NORAM_PX;
       stop = 0;


### PR DESCRIPTION
- if a segment is destroyed or turned inactive, disable the gif player: only one gif player instance can run at a time, if a inactive or destroyed segment uses it, the effect is broken for other segments.
- copy FX ironically copied the source segment on each call, should use reference not a copy!