### PR TITLE
Correct broken esp32dev_8M enviroment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -450,7 +450,7 @@ board_build.partitions = ${esp32.large_partitions}
 board_upload.flash_size = 8MB
 board_upload.maximum_size = 8388608
 ; board_build.f_flash = 80000000L
-; board_build.flash_mode = qio
+board_build.flash_mode = dio
 
 [env:esp32dev_16M]
 board = esp32dev


### PR DESCRIPTION
esp32dev_8M: add flash_mode, otherwise it cannot be compiled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated ESP32 8M build configuration to use DIO flash mode, improving firmware flashing reliability and reducing intermittent boot issues on affected devices.

- Chores
  - Adjusted build settings for ESP32 8M environment. No changes to user-facing features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->