### PR TITLE
(POC) Large effect count management

### DIFF
--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.cpp
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.cpp
@@ -178,9 +178,6 @@ class RotaryEncoderUIUsermod : public Usermod {
     void* display;
   #endif
 
-    // Pointers the start of the mode names within JSON_mode_names
-    const char **modes_qstrings;
-
     // Array of mode indexes in alphabetical order.
     byte *modes_alpha_indexes;
 
@@ -265,7 +262,6 @@ class RotaryEncoderUIUsermod : public Usermod {
       , currentSat1(255)
       , currentCCT(128)
       , display(nullptr)
-      , modes_qstrings(nullptr)
       , modes_alpha_indexes(nullptr)
       , palettes_qstrings(nullptr)
       , palettes_alpha_indexes(nullptr)
@@ -395,10 +391,12 @@ byte RotaryEncoderUIUsermod::readPin(uint8_t pin) {
  */
 void RotaryEncoderUIUsermod::sortModesAndPalettes() {
   DEBUG_PRINT(F("Sorting modes: ")); DEBUG_PRINTLN(strip.getModeCount());
-  //modes_qstrings = re_findModeStrings(JSON_mode_names, strip.getModeCount());
-  modes_qstrings = strip.getModeDataSrc();
+  std::vector<const char*> modes_qstrings  { strip.getModeCount(), "RSVD" };
+  for (auto& effect_ptr: Effects::all()) {
+    modes_qstrings[Effects::getIdForEffect(effect_ptr)] = effect_ptr->data;
+  }
   modes_alpha_indexes = re_initIndexArray(strip.getModeCount());
-  re_sortModes(modes_qstrings, modes_alpha_indexes, strip.getModeCount(), MODE_SORT_SKIP_COUNT);
+  re_sortModes(modes_qstrings.data(), modes_alpha_indexes, strip.getModeCount(), MODE_SORT_SKIP_COUNT);
 
   DEBUG_PRINT(F("Sorting palettes: ")); DEBUG_PRINT(getPaletteCount()); DEBUG_PRINT('/'); DEBUG_PRINTLN(customPalettes.size());
   palettes_qstrings = re_findModeStrings(JSON_palette_names, getPaletteCount());

--- a/wled00/Effects.cpp
+++ b/wled00/Effects.cpp
@@ -1,0 +1,107 @@
+#include "wled.h"
+#include "FX.h"
+#include <new>
+
+// Namespace Effects: Global effects list
+// Construct-on-first-use idiom to avoid static initialization fiasco with WS2812FX
+static std::vector<const Effect*>& _globalEffectsList() {
+  static std::vector<const Effect*>* _g = new std::vector<const Effect*>{};
+  return *_g;
+};
+
+// Highest used effect ID
+static uint8_t _highestId = 0;
+
+void Effects::reserve(size_t s) { 
+  _globalEffectsList().reserve(s);
+}
+
+void Effects::addEffect(const Effect* new_effect) {
+  if (new_effect) {
+    _globalEffectsList().push_back(new_effect);
+    auto id = getIdForEffect(new_effect);
+    if (id > _highestId) {
+      _highestId = id;
+    }
+  }
+}
+
+uint8_t Effects::addEffect(const char *mode_name, effect_function mode_fn, uint8_t id) {
+  if (id == 255) { // find next available id
+    // Build a quick bitmap of the used IDs
+    uint32_t used_ids[8] = {0};
+    for(auto& e: _globalEffectsList()) {
+      auto id = getIdForEffect(e);
+      if (id != 255) {
+        // Do math together so the compiler identifies the division+remainder 
+        auto chunk = id/32;
+        auto bit = id%32;
+        used_ids[chunk] |= (1u << bit);
+      }
+    }
+    // Now find the lowest value
+    for(auto chunk = 0U; chunk < 8; ++chunk) {
+      auto inverted = ~used_ids[chunk];
+      if (inverted) {
+        // found one!
+        id = (chunk*32) + __builtin_ctz(inverted);  // Find lowest set bit with compiler intrinsic
+        break;
+      }
+    }
+  }
+
+  addEffect(new(std::nothrow) Effect { mode_name, mode_fn, id });
+  return id;
+}
+
+// const Effect* Effects::getEffectByName(const char* name) {}  TODO
+
+const Effect* Effects::getEffectById(uint8_t id) {
+  auto effect_iter = std::find_if(_globalEffectsList().begin(), _globalEffectsList().end(), [=](const Effect* e) { return getIdForEffect(e) == id; });
+  if (effect_iter == _globalEffectsList().end()) effect_iter = _globalEffectsList().begin(); // set solid mode, always the first element of the list  
+  return *effect_iter;
+}
+
+uint8_t Effects::getHighestId() { return _highestId; };
+
+size_t Effects::getCount() { return _globalEffectsList().size(); }
+size_t Effects::getCapacity() { return _globalEffectsList().capacity(); }
+  
+// Range interface: for(auto& effect: Effects.all())
+std::vector<const Effect*>::iterator Effects::asRange::begin() { return _globalEffectsList().begin(); }
+std::vector<const Effect*>::iterator Effects::asRange::end() { return _globalEffectsList().end(); }
+
+
+// Effect parsing utilities
+String Effect::getName() const {
+#ifdef ESP8266
+  char lineBuffer[256];
+  strncpy_P(lineBuffer, data, sizeof(lineBuffer)/sizeof(char)-1);
+  lineBuffer[sizeof(lineBuffer)/sizeof(char)-1] = '\0'; // terminate string
+  char* p = strchr(lineBuffer, '@');
+  if (p) {
+    *p = '\0'; // terminate there
+  }
+  return String(lineBuffer);
+#else
+  char* p = strchr(data, '@');
+  if (p) {
+    return String(data, p - data);
+  } else {
+    return String(data);
+  }
+#endif  
+}
+
+size_t Effect::getName(char* dest, size_t dest_size) const {
+  char lineBuffer[256];
+  strncpy_P(lineBuffer, data, sizeof(lineBuffer)/sizeof(char)-1);
+  lineBuffer[sizeof(lineBuffer)/sizeof(char)-1] = '\0'; // terminate string
+  size_t j = 0;
+  for (; j < dest_size; j++) {
+    if (lineBuffer[j] == '\0' || lineBuffer[j] == '@') break;
+    dest[j] = lineBuffer[j];
+  }
+  dest[j] = 0; // terminate string
+  return strlen(dest);
+}

--- a/wled00/Effects.cpp
+++ b/wled00/Effects.cpp
@@ -54,7 +54,14 @@ uint8_t Effects::addEffect(const char *mode_name, effect_function mode_fn, uint8
   return id;
 }
 
-// const Effect* Effects::getEffectByName(const char* name) {}  TODO
+const Effect* Effects::getEffectByName(const char* name, size_t len) {
+  auto effect_iter = std::find_if(_globalEffectsList().begin(), _globalEffectsList().end(), [=](const Effect* e) { 
+      auto match = strncmp_P(e->data, name, len);
+      return (match == 0) && ((e->data[len] == '@') || (e->data[len] == 0));
+    });
+  if (effect_iter == _globalEffectsList().end()) effect_iter = _globalEffectsList().begin(); // set solid mode, always the first element of the list  
+  return *effect_iter;  
+}
 
 const Effect* Effects::getEffectById(uint8_t id) {
   auto effect_iter = std::find_if(_globalEffectsList().begin(), _globalEffectsList().end(), [=](const Effect* e) { return getIdForEffect(e) == id; });

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -10750,247 +10750,248 @@ static const char _data_FX_MODE_PS_SPRINGY[] PROGMEM = "PS Springy@Stiffness,Dam
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // mode data
+#define ADD_EFFECT_STATIC(id, func, data) { const static Effect func ## _e PROGMEM {data, func, id}; Effects::addEffect(& func ## _e); }
 
 void WS2812FX::setupEffectData() {
   // TODO: make this a static initializer for _effects
-  addEffect(FX_MODE_STATIC, mode_static, _data_FX_MODE_STATIC);
+  ADD_EFFECT_STATIC(FX_MODE_STATIC, mode_static, _data_FX_MODE_STATIC);
 
   // now add all pre-allocated effects
-  addEffect(FX_MODE_COPY, &mode_copy_segment, _data_FX_MODE_COPY);
+  ADD_EFFECT_STATIC(FX_MODE_COPY, mode_copy_segment, _data_FX_MODE_COPY);
   // --- 1D non-audio effects ---
-  addEffect(FX_MODE_BLINK, &mode_blink, _data_FX_MODE_BLINK);
-  addEffect(FX_MODE_BREATH, &mode_breath, _data_FX_MODE_BREATH);
-  addEffect(FX_MODE_COLOR_WIPE, &mode_color_wipe, _data_FX_MODE_COLOR_WIPE);
-  addEffect(FX_MODE_COLOR_WIPE_RANDOM, &mode_color_wipe_random, _data_FX_MODE_COLOR_WIPE_RANDOM);
-  addEffect(FX_MODE_RANDOM_COLOR, &mode_random_color, _data_FX_MODE_RANDOM_COLOR);
-  addEffect(FX_MODE_COLOR_SWEEP, &mode_color_sweep, _data_FX_MODE_COLOR_SWEEP);
-  addEffect(FX_MODE_DYNAMIC, &mode_dynamic, _data_FX_MODE_DYNAMIC);
-  addEffect(FX_MODE_RAINBOW, &mode_rainbow, _data_FX_MODE_RAINBOW);
-  addEffect(FX_MODE_RAINBOW_CYCLE, &mode_rainbow_cycle, _data_FX_MODE_RAINBOW_CYCLE);
-  addEffect(FX_MODE_SCAN, &mode_scan, _data_FX_MODE_SCAN);
-  addEffect(FX_MODE_DUAL_SCAN, &mode_dual_scan, _data_FX_MODE_DUAL_SCAN);
-  addEffect(FX_MODE_FADE, &mode_fade, _data_FX_MODE_FADE);
-  addEffect(FX_MODE_THEATER_CHASE, &mode_theater_chase, _data_FX_MODE_THEATER_CHASE);
-  addEffect(FX_MODE_THEATER_CHASE_RAINBOW, &mode_theater_chase_rainbow, _data_FX_MODE_THEATER_CHASE_RAINBOW);
-  addEffect(FX_MODE_RUNNING_LIGHTS, &mode_running_lights, _data_FX_MODE_RUNNING_LIGHTS);
-  addEffect(FX_MODE_SAW, &mode_saw, _data_FX_MODE_SAW);
-  addEffect(FX_MODE_TWINKLE, &mode_twinkle, _data_FX_MODE_TWINKLE);
-  addEffect(FX_MODE_DISSOLVE, &mode_dissolve, _data_FX_MODE_DISSOLVE);
-  addEffect(FX_MODE_DISSOLVE_RANDOM, &mode_dissolve_random, _data_FX_MODE_DISSOLVE_RANDOM);
-  addEffect(FX_MODE_FLASH_SPARKLE, &mode_flash_sparkle, _data_FX_MODE_FLASH_SPARKLE);
-  addEffect(FX_MODE_HYPER_SPARKLE, &mode_hyper_sparkle, _data_FX_MODE_HYPER_SPARKLE);
-  addEffect(FX_MODE_STROBE, &mode_strobe, _data_FX_MODE_STROBE);
-  addEffect(FX_MODE_STROBE_RAINBOW, &mode_strobe_rainbow, _data_FX_MODE_STROBE_RAINBOW);
-  addEffect(FX_MODE_MULTI_STROBE, &mode_multi_strobe, _data_FX_MODE_MULTI_STROBE);
-  addEffect(FX_MODE_BLINK_RAINBOW, &mode_blink_rainbow, _data_FX_MODE_BLINK_RAINBOW);
-  addEffect(FX_MODE_ANDROID, &mode_android, _data_FX_MODE_ANDROID);
-  addEffect(FX_MODE_CHASE_COLOR, &mode_chase_color, _data_FX_MODE_CHASE_COLOR);
-  addEffect(FX_MODE_CHASE_RANDOM, &mode_chase_random, _data_FX_MODE_CHASE_RANDOM);
-  addEffect(FX_MODE_CHASE_RAINBOW, &mode_chase_rainbow, _data_FX_MODE_CHASE_RAINBOW);
-  addEffect(FX_MODE_CHASE_FLASH, &mode_chase_flash, _data_FX_MODE_CHASE_FLASH);
-  addEffect(FX_MODE_CHASE_FLASH_RANDOM, &mode_chase_flash_random, _data_FX_MODE_CHASE_FLASH_RANDOM);
-  addEffect(FX_MODE_CHASE_RAINBOW_WHITE, &mode_chase_rainbow_white, _data_FX_MODE_CHASE_RAINBOW_WHITE);
-  addEffect(FX_MODE_COLORFUL, &mode_colorful, _data_FX_MODE_COLORFUL);
-  addEffect(FX_MODE_TRAFFIC_LIGHT, &mode_traffic_light, _data_FX_MODE_TRAFFIC_LIGHT);
-  addEffect(FX_MODE_COLOR_SWEEP_RANDOM, &mode_color_sweep_random, _data_FX_MODE_COLOR_SWEEP_RANDOM);
-  addEffect(FX_MODE_RUNNING_COLOR, &mode_running_color, _data_FX_MODE_RUNNING_COLOR);
-  addEffect(FX_MODE_AURORA, &mode_aurora, _data_FX_MODE_AURORA);
-  addEffect(FX_MODE_RUNNING_RANDOM, &mode_running_random, _data_FX_MODE_RUNNING_RANDOM);
-  addEffect(FX_MODE_LARSON_SCANNER, &mode_larson_scanner, _data_FX_MODE_LARSON_SCANNER);
-  addEffect(FX_MODE_RAIN, &mode_rain, _data_FX_MODE_RAIN);
-  addEffect(FX_MODE_PRIDE_2015, &mode_pride_2015, _data_FX_MODE_PRIDE_2015);
-  addEffect(FX_MODE_COLORWAVES, &mode_colorwaves, _data_FX_MODE_COLORWAVES);
-  addEffect(FX_MODE_FIREWORKS, &mode_fireworks, _data_FX_MODE_FIREWORKS);
-  addEffect(FX_MODE_TETRIX, &mode_tetrix, _data_FX_MODE_TETRIX);
-  addEffect(FX_MODE_FIRE_FLICKER, &mode_fire_flicker, _data_FX_MODE_FIRE_FLICKER);
-  addEffect(FX_MODE_GRADIENT, &mode_gradient, _data_FX_MODE_GRADIENT);
-  addEffect(FX_MODE_LOADING, &mode_loading, _data_FX_MODE_LOADING);
-  addEffect(FX_MODE_FAIRY, &mode_fairy, _data_FX_MODE_FAIRY);
-  addEffect(FX_MODE_TWO_DOTS, &mode_two_dots, _data_FX_MODE_TWO_DOTS);
-  addEffect(FX_MODE_FAIRYTWINKLE, &mode_fairytwinkle, _data_FX_MODE_FAIRYTWINKLE);
-  addEffect(FX_MODE_RUNNING_DUAL, &mode_running_dual, _data_FX_MODE_RUNNING_DUAL);
+  ADD_EFFECT_STATIC(FX_MODE_BLINK, mode_blink, _data_FX_MODE_BLINK);
+  ADD_EFFECT_STATIC(FX_MODE_BREATH, mode_breath, _data_FX_MODE_BREATH);
+  ADD_EFFECT_STATIC(FX_MODE_COLOR_WIPE, mode_color_wipe, _data_FX_MODE_COLOR_WIPE);
+  ADD_EFFECT_STATIC(FX_MODE_COLOR_WIPE_RANDOM, mode_color_wipe_random, _data_FX_MODE_COLOR_WIPE_RANDOM);
+  ADD_EFFECT_STATIC(FX_MODE_RANDOM_COLOR, mode_random_color, _data_FX_MODE_RANDOM_COLOR);
+  ADD_EFFECT_STATIC(FX_MODE_COLOR_SWEEP, mode_color_sweep, _data_FX_MODE_COLOR_SWEEP);
+  ADD_EFFECT_STATIC(FX_MODE_DYNAMIC, mode_dynamic, _data_FX_MODE_DYNAMIC);
+  ADD_EFFECT_STATIC(FX_MODE_RAINBOW, mode_rainbow, _data_FX_MODE_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_RAINBOW_CYCLE, mode_rainbow_cycle, _data_FX_MODE_RAINBOW_CYCLE);
+  ADD_EFFECT_STATIC(FX_MODE_SCAN, mode_scan, _data_FX_MODE_SCAN);
+  ADD_EFFECT_STATIC(FX_MODE_DUAL_SCAN, mode_dual_scan, _data_FX_MODE_DUAL_SCAN);
+  ADD_EFFECT_STATIC(FX_MODE_FADE, mode_fade, _data_FX_MODE_FADE);
+  ADD_EFFECT_STATIC(FX_MODE_THEATER_CHASE, mode_theater_chase, _data_FX_MODE_THEATER_CHASE);
+  ADD_EFFECT_STATIC(FX_MODE_THEATER_CHASE_RAINBOW, mode_theater_chase_rainbow, _data_FX_MODE_THEATER_CHASE_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_RUNNING_LIGHTS, mode_running_lights, _data_FX_MODE_RUNNING_LIGHTS);
+  ADD_EFFECT_STATIC(FX_MODE_SAW, mode_saw, _data_FX_MODE_SAW);
+  ADD_EFFECT_STATIC(FX_MODE_TWINKLE, mode_twinkle, _data_FX_MODE_TWINKLE);
+  ADD_EFFECT_STATIC(FX_MODE_DISSOLVE, mode_dissolve, _data_FX_MODE_DISSOLVE);
+  ADD_EFFECT_STATIC(FX_MODE_DISSOLVE_RANDOM, mode_dissolve_random, _data_FX_MODE_DISSOLVE_RANDOM);
+  ADD_EFFECT_STATIC(FX_MODE_FLASH_SPARKLE, mode_flash_sparkle, _data_FX_MODE_FLASH_SPARKLE);
+  ADD_EFFECT_STATIC(FX_MODE_HYPER_SPARKLE, mode_hyper_sparkle, _data_FX_MODE_HYPER_SPARKLE);
+  ADD_EFFECT_STATIC(FX_MODE_STROBE, mode_strobe, _data_FX_MODE_STROBE);
+  ADD_EFFECT_STATIC(FX_MODE_STROBE_RAINBOW, mode_strobe_rainbow, _data_FX_MODE_STROBE_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_MULTI_STROBE, mode_multi_strobe, _data_FX_MODE_MULTI_STROBE);
+  ADD_EFFECT_STATIC(FX_MODE_BLINK_RAINBOW, mode_blink_rainbow, _data_FX_MODE_BLINK_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_ANDROID, mode_android, _data_FX_MODE_ANDROID);
+  ADD_EFFECT_STATIC(FX_MODE_CHASE_COLOR, mode_chase_color, _data_FX_MODE_CHASE_COLOR);
+  ADD_EFFECT_STATIC(FX_MODE_CHASE_RANDOM, mode_chase_random, _data_FX_MODE_CHASE_RANDOM);
+  ADD_EFFECT_STATIC(FX_MODE_CHASE_RAINBOW, mode_chase_rainbow, _data_FX_MODE_CHASE_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_CHASE_FLASH, mode_chase_flash, _data_FX_MODE_CHASE_FLASH);
+  ADD_EFFECT_STATIC(FX_MODE_CHASE_FLASH_RANDOM, mode_chase_flash_random, _data_FX_MODE_CHASE_FLASH_RANDOM);
+  ADD_EFFECT_STATIC(FX_MODE_CHASE_RAINBOW_WHITE, mode_chase_rainbow_white, _data_FX_MODE_CHASE_RAINBOW_WHITE);
+  ADD_EFFECT_STATIC(FX_MODE_COLORFUL, mode_colorful, _data_FX_MODE_COLORFUL);
+  ADD_EFFECT_STATIC(FX_MODE_TRAFFIC_LIGHT, mode_traffic_light, _data_FX_MODE_TRAFFIC_LIGHT);
+  ADD_EFFECT_STATIC(FX_MODE_COLOR_SWEEP_RANDOM, mode_color_sweep_random, _data_FX_MODE_COLOR_SWEEP_RANDOM);
+  ADD_EFFECT_STATIC(FX_MODE_RUNNING_COLOR, mode_running_color, _data_FX_MODE_RUNNING_COLOR);
+  ADD_EFFECT_STATIC(FX_MODE_AURORA, mode_aurora, _data_FX_MODE_AURORA);
+  ADD_EFFECT_STATIC(FX_MODE_RUNNING_RANDOM, mode_running_random, _data_FX_MODE_RUNNING_RANDOM);
+  ADD_EFFECT_STATIC(FX_MODE_LARSON_SCANNER, mode_larson_scanner, _data_FX_MODE_LARSON_SCANNER);
+  ADD_EFFECT_STATIC(FX_MODE_RAIN, mode_rain, _data_FX_MODE_RAIN);
+  ADD_EFFECT_STATIC(FX_MODE_PRIDE_2015, mode_pride_2015, _data_FX_MODE_PRIDE_2015);
+  ADD_EFFECT_STATIC(FX_MODE_COLORWAVES, mode_colorwaves, _data_FX_MODE_COLORWAVES);
+  ADD_EFFECT_STATIC(FX_MODE_FIREWORKS, mode_fireworks, _data_FX_MODE_FIREWORKS);
+  ADD_EFFECT_STATIC(FX_MODE_TETRIX, mode_tetrix, _data_FX_MODE_TETRIX);
+  ADD_EFFECT_STATIC(FX_MODE_FIRE_FLICKER, mode_fire_flicker, _data_FX_MODE_FIRE_FLICKER);
+  ADD_EFFECT_STATIC(FX_MODE_GRADIENT, mode_gradient, _data_FX_MODE_GRADIENT);
+  ADD_EFFECT_STATIC(FX_MODE_LOADING, mode_loading, _data_FX_MODE_LOADING);
+  ADD_EFFECT_STATIC(FX_MODE_FAIRY, mode_fairy, _data_FX_MODE_FAIRY);
+  ADD_EFFECT_STATIC(FX_MODE_TWO_DOTS, mode_two_dots, _data_FX_MODE_TWO_DOTS);
+  ADD_EFFECT_STATIC(FX_MODE_FAIRYTWINKLE, mode_fairytwinkle, _data_FX_MODE_FAIRYTWINKLE);
+  ADD_EFFECT_STATIC(FX_MODE_RUNNING_DUAL, mode_running_dual, _data_FX_MODE_RUNNING_DUAL);
   #ifdef WLED_ENABLE_GIF
-  addEffect(FX_MODE_IMAGE, &mode_image, _data_FX_MODE_IMAGE);
+  ADD_EFFECT_STATIC(FX_MODE_IMAGE, mode_image, _data_FX_MODE_IMAGE);
   #endif
-  addEffect(FX_MODE_TRICOLOR_CHASE, &mode_tricolor_chase, _data_FX_MODE_TRICOLOR_CHASE);
-  addEffect(FX_MODE_TRICOLOR_WIPE, &mode_tricolor_wipe, _data_FX_MODE_TRICOLOR_WIPE);
-  addEffect(FX_MODE_TRICOLOR_FADE, &mode_tricolor_fade, _data_FX_MODE_TRICOLOR_FADE);
-  addEffect(FX_MODE_LIGHTNING, &mode_lightning, _data_FX_MODE_LIGHTNING);
-  addEffect(FX_MODE_ICU, &mode_icu, _data_FX_MODE_ICU);
-  addEffect(FX_MODE_DUAL_LARSON_SCANNER, &mode_dual_larson_scanner, _data_FX_MODE_DUAL_LARSON_SCANNER);
-  addEffect(FX_MODE_RANDOM_CHASE, &mode_random_chase, _data_FX_MODE_RANDOM_CHASE);
-  addEffect(FX_MODE_OSCILLATE, &mode_oscillate, _data_FX_MODE_OSCILLATE);
-  addEffect(FX_MODE_JUGGLE, &mode_juggle, _data_FX_MODE_JUGGLE);
-  addEffect(FX_MODE_PALETTE, &mode_palette, _data_FX_MODE_PALETTE);
-  addEffect(FX_MODE_BPM, &mode_bpm, _data_FX_MODE_BPM);
-  addEffect(FX_MODE_FILLNOISE8, &mode_fillnoise8, _data_FX_MODE_FILLNOISE8);
-  addEffect(FX_MODE_NOISE16_1, &mode_noise16_1, _data_FX_MODE_NOISE16_1);
-  addEffect(FX_MODE_NOISE16_2, &mode_noise16_2, _data_FX_MODE_NOISE16_2);
-  addEffect(FX_MODE_NOISE16_3, &mode_noise16_3, _data_FX_MODE_NOISE16_3);
-  addEffect(FX_MODE_NOISE16_4, &mode_noise16_4, _data_FX_MODE_NOISE16_4);
-  addEffect(FX_MODE_COLORTWINKLE, &mode_colortwinkle, _data_FX_MODE_COLORTWINKLE);
-  addEffect(FX_MODE_LAKE, &mode_lake, _data_FX_MODE_LAKE);
-  addEffect(FX_MODE_METEOR, &mode_meteor, _data_FX_MODE_METEOR);
-  //addEffect(FX_MODE_METEOR_SMOOTH, &mode_meteor_smooth, _data_FX_MODE_METEOR_SMOOTH); // merged with mode_meteor 
-  addEffect(FX_MODE_RAILWAY, &mode_railway, _data_FX_MODE_RAILWAY);
-  addEffect(FX_MODE_RIPPLE, &mode_ripple, _data_FX_MODE_RIPPLE);
-  addEffect(FX_MODE_TWINKLEFOX, &mode_twinklefox, _data_FX_MODE_TWINKLEFOX);
-  addEffect(FX_MODE_TWINKLECAT, &mode_twinklecat, _data_FX_MODE_TWINKLECAT);
-  addEffect(FX_MODE_HALLOWEEN_EYES, &mode_halloween_eyes, _data_FX_MODE_HALLOWEEN_EYES);
-  addEffect(FX_MODE_STATIC_PATTERN, &mode_static_pattern, _data_FX_MODE_STATIC_PATTERN);
-  addEffect(FX_MODE_TRI_STATIC_PATTERN, &mode_tri_static_pattern, _data_FX_MODE_TRI_STATIC_PATTERN);
-  addEffect(FX_MODE_SPOTS, &mode_spots, _data_FX_MODE_SPOTS);
-  addEffect(FX_MODE_SPOTS_FADE, &mode_spots_fade, _data_FX_MODE_SPOTS_FADE);
-  addEffect(FX_MODE_COMET, &mode_comet, _data_FX_MODE_COMET);
+  ADD_EFFECT_STATIC(FX_MODE_TRICOLOR_CHASE, mode_tricolor_chase, _data_FX_MODE_TRICOLOR_CHASE);
+  ADD_EFFECT_STATIC(FX_MODE_TRICOLOR_WIPE, mode_tricolor_wipe, _data_FX_MODE_TRICOLOR_WIPE);
+  ADD_EFFECT_STATIC(FX_MODE_TRICOLOR_FADE, mode_tricolor_fade, _data_FX_MODE_TRICOLOR_FADE);
+  ADD_EFFECT_STATIC(FX_MODE_LIGHTNING, mode_lightning, _data_FX_MODE_LIGHTNING);
+  ADD_EFFECT_STATIC(FX_MODE_ICU, mode_icu, _data_FX_MODE_ICU);
+  ADD_EFFECT_STATIC(FX_MODE_DUAL_LARSON_SCANNER, mode_dual_larson_scanner, _data_FX_MODE_DUAL_LARSON_SCANNER);
+  ADD_EFFECT_STATIC(FX_MODE_RANDOM_CHASE, mode_random_chase, _data_FX_MODE_RANDOM_CHASE);
+  ADD_EFFECT_STATIC(FX_MODE_OSCILLATE, mode_oscillate, _data_FX_MODE_OSCILLATE);
+  ADD_EFFECT_STATIC(FX_MODE_JUGGLE, mode_juggle, _data_FX_MODE_JUGGLE);
+  ADD_EFFECT_STATIC(FX_MODE_PALETTE, mode_palette, _data_FX_MODE_PALETTE);
+  ADD_EFFECT_STATIC(FX_MODE_BPM, mode_bpm, _data_FX_MODE_BPM);
+  ADD_EFFECT_STATIC(FX_MODE_FILLNOISE8, mode_fillnoise8, _data_FX_MODE_FILLNOISE8);
+  ADD_EFFECT_STATIC(FX_MODE_NOISE16_1, mode_noise16_1, _data_FX_MODE_NOISE16_1);
+  ADD_EFFECT_STATIC(FX_MODE_NOISE16_2, mode_noise16_2, _data_FX_MODE_NOISE16_2);
+  ADD_EFFECT_STATIC(FX_MODE_NOISE16_3, mode_noise16_3, _data_FX_MODE_NOISE16_3);
+  ADD_EFFECT_STATIC(FX_MODE_NOISE16_4, mode_noise16_4, _data_FX_MODE_NOISE16_4);
+  ADD_EFFECT_STATIC(FX_MODE_COLORTWINKLE, mode_colortwinkle, _data_FX_MODE_COLORTWINKLE);
+  ADD_EFFECT_STATIC(FX_MODE_LAKE, mode_lake, _data_FX_MODE_LAKE);
+  ADD_EFFECT_STATIC(FX_MODE_METEOR, mode_meteor, _data_FX_MODE_METEOR);
+  //ADD_EFFECT_STATIC(FX_MODE_METEOR_SMOOTH, mode_meteor_smooth, _data_FX_MODE_METEOR_SMOOTH); // merged with mode_meteor 
+  ADD_EFFECT_STATIC(FX_MODE_RAILWAY, mode_railway, _data_FX_MODE_RAILWAY);
+  ADD_EFFECT_STATIC(FX_MODE_RIPPLE, mode_ripple, _data_FX_MODE_RIPPLE);
+  ADD_EFFECT_STATIC(FX_MODE_TWINKLEFOX, mode_twinklefox, _data_FX_MODE_TWINKLEFOX);
+  ADD_EFFECT_STATIC(FX_MODE_TWINKLECAT, mode_twinklecat, _data_FX_MODE_TWINKLECAT);
+  ADD_EFFECT_STATIC(FX_MODE_HALLOWEEN_EYES, mode_halloween_eyes, _data_FX_MODE_HALLOWEEN_EYES);
+  ADD_EFFECT_STATIC(FX_MODE_STATIC_PATTERN, mode_static_pattern, _data_FX_MODE_STATIC_PATTERN);
+  ADD_EFFECT_STATIC(FX_MODE_TRI_STATIC_PATTERN, mode_tri_static_pattern, _data_FX_MODE_TRI_STATIC_PATTERN);
+  ADD_EFFECT_STATIC(FX_MODE_SPOTS, mode_spots, _data_FX_MODE_SPOTS);
+  ADD_EFFECT_STATIC(FX_MODE_SPOTS_FADE, mode_spots_fade, _data_FX_MODE_SPOTS_FADE);
+  ADD_EFFECT_STATIC(FX_MODE_COMET, mode_comet, _data_FX_MODE_COMET);
   #ifdef WLED_PS_DONT_REPLACE_FX
-  addEffect(FX_MODE_MULTI_COMET, &mode_multi_comet, _data_FX_MODE_MULTI_COMET);  
+  ADD_EFFECT_STATIC(FX_MODE_MULTI_COMET, mode_multi_comet, _data_FX_MODE_MULTI_COMET);  
   addEffect(FX_MODE_ROLLINGBALLS, &rolling_balls, _data_FX_MODE_ROLLINGBALLS);
-  addEffect(FX_MODE_SPARKLE, &mode_sparkle, _data_FX_MODE_SPARKLE);
-  addEffect(FX_MODE_GLITTER, &mode_glitter, _data_FX_MODE_GLITTER);
-  addEffect(FX_MODE_SOLID_GLITTER, &mode_solid_glitter, _data_FX_MODE_SOLID_GLITTER);
-  addEffect(FX_MODE_STARBURST, &mode_starburst, _data_FX_MODE_STARBURST);
-  addEffect(FX_MODE_DANCING_SHADOWS, &mode_dancing_shadows, _data_FX_MODE_DANCING_SHADOWS);
-  addEffect(FX_MODE_FIRE_2012, &mode_fire_2012, _data_FX_MODE_FIRE_2012);
-  addEffect(FX_MODE_EXPLODING_FIREWORKS, &mode_exploding_fireworks, _data_FX_MODE_EXPLODING_FIREWORKS);
+  ADD_EFFECT_STATIC(FX_MODE_SPARKLE, mode_sparkle, _data_FX_MODE_SPARKLE);
+  ADD_EFFECT_STATIC(FX_MODE_GLITTER, mode_glitter, _data_FX_MODE_GLITTER);
+  ADD_EFFECT_STATIC(FX_MODE_SOLID_GLITTER, mode_solid_glitter, _data_FX_MODE_SOLID_GLITTER);
+  ADD_EFFECT_STATIC(FX_MODE_STARBURST, mode_starburst, _data_FX_MODE_STARBURST);
+  ADD_EFFECT_STATIC(FX_MODE_DANCING_SHADOWS, mode_dancing_shadows, _data_FX_MODE_DANCING_SHADOWS);
+  ADD_EFFECT_STATIC(FX_MODE_FIRE_2012, mode_fire_2012, _data_FX_MODE_FIRE_2012);
+  ADD_EFFECT_STATIC(FX_MODE_EXPLODING_FIREWORKS, mode_exploding_fireworks, _data_FX_MODE_EXPLODING_FIREWORKS);
   #endif
-  addEffect(FX_MODE_CANDLE, &mode_candle, _data_FX_MODE_CANDLE);
-  addEffect(FX_MODE_BOUNCINGBALLS, &mode_bouncing_balls, _data_FX_MODE_BOUNCINGBALLS);
-  addEffect(FX_MODE_POPCORN, &mode_popcorn, _data_FX_MODE_POPCORN);
-  addEffect(FX_MODE_DRIP, &mode_drip, _data_FX_MODE_DRIP);
-  addEffect(FX_MODE_SINELON, &mode_sinelon, _data_FX_MODE_SINELON);
-  addEffect(FX_MODE_SINELON_DUAL, &mode_sinelon_dual, _data_FX_MODE_SINELON_DUAL);
-  addEffect(FX_MODE_SINELON_RAINBOW, &mode_sinelon_rainbow, _data_FX_MODE_SINELON_RAINBOW);
-  addEffect(FX_MODE_PLASMA, &mode_plasma, _data_FX_MODE_PLASMA);
-  addEffect(FX_MODE_PERCENT, &mode_percent, _data_FX_MODE_PERCENT);
-  addEffect(FX_MODE_RIPPLE_RAINBOW, &mode_ripple_rainbow, _data_FX_MODE_RIPPLE_RAINBOW);
-  addEffect(FX_MODE_HEARTBEAT, &mode_heartbeat, _data_FX_MODE_HEARTBEAT);
-  addEffect(FX_MODE_PACIFICA, &mode_pacifica, _data_FX_MODE_PACIFICA);
-  addEffect(FX_MODE_CANDLE_MULTI, &mode_candle_multi, _data_FX_MODE_CANDLE_MULTI);
-  addEffect(FX_MODE_SUNRISE, &mode_sunrise, _data_FX_MODE_SUNRISE);
-  addEffect(FX_MODE_PHASED, &mode_phased, _data_FX_MODE_PHASED);
-  addEffect(FX_MODE_TWINKLEUP, &mode_twinkleup, _data_FX_MODE_TWINKLEUP);
-  addEffect(FX_MODE_NOISEPAL, &mode_noisepal, _data_FX_MODE_NOISEPAL);
-  addEffect(FX_MODE_SINEWAVE, &mode_sinewave, _data_FX_MODE_SINEWAVE);
-  addEffect(FX_MODE_PHASEDNOISE, &mode_phased_noise, _data_FX_MODE_PHASEDNOISE);
-  addEffect(FX_MODE_FLOW, &mode_flow, _data_FX_MODE_FLOW);
-  addEffect(FX_MODE_CHUNCHUN, &mode_chunchun, _data_FX_MODE_CHUNCHUN);  
-  addEffect(FX_MODE_WASHING_MACHINE, &mode_washing_machine, _data_FX_MODE_WASHING_MACHINE);
-  addEffect(FX_MODE_BLENDS, &mode_blends, _data_FX_MODE_BLENDS);
-  addEffect(FX_MODE_TV_SIMULATOR, &mode_tv_simulator, _data_FX_MODE_TV_SIMULATOR);
-  addEffect(FX_MODE_DYNAMIC_SMOOTH, &mode_dynamic_smooth, _data_FX_MODE_DYNAMIC_SMOOTH);
+  ADD_EFFECT_STATIC(FX_MODE_CANDLE, mode_candle, _data_FX_MODE_CANDLE);
+  ADD_EFFECT_STATIC(FX_MODE_BOUNCINGBALLS, mode_bouncing_balls, _data_FX_MODE_BOUNCINGBALLS);
+  ADD_EFFECT_STATIC(FX_MODE_POPCORN, mode_popcorn, _data_FX_MODE_POPCORN);
+  ADD_EFFECT_STATIC(FX_MODE_DRIP, mode_drip, _data_FX_MODE_DRIP);
+  ADD_EFFECT_STATIC(FX_MODE_SINELON, mode_sinelon, _data_FX_MODE_SINELON);
+  ADD_EFFECT_STATIC(FX_MODE_SINELON_DUAL, mode_sinelon_dual, _data_FX_MODE_SINELON_DUAL);
+  ADD_EFFECT_STATIC(FX_MODE_SINELON_RAINBOW, mode_sinelon_rainbow, _data_FX_MODE_SINELON_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_PLASMA, mode_plasma, _data_FX_MODE_PLASMA);
+  ADD_EFFECT_STATIC(FX_MODE_PERCENT, mode_percent, _data_FX_MODE_PERCENT);
+  ADD_EFFECT_STATIC(FX_MODE_RIPPLE_RAINBOW, mode_ripple_rainbow, _data_FX_MODE_RIPPLE_RAINBOW);
+  ADD_EFFECT_STATIC(FX_MODE_HEARTBEAT, mode_heartbeat, _data_FX_MODE_HEARTBEAT);
+  ADD_EFFECT_STATIC(FX_MODE_PACIFICA, mode_pacifica, _data_FX_MODE_PACIFICA);
+  ADD_EFFECT_STATIC(FX_MODE_CANDLE_MULTI, mode_candle_multi, _data_FX_MODE_CANDLE_MULTI);
+  ADD_EFFECT_STATIC(FX_MODE_SUNRISE, mode_sunrise, _data_FX_MODE_SUNRISE);
+  ADD_EFFECT_STATIC(FX_MODE_PHASED, mode_phased, _data_FX_MODE_PHASED);
+  ADD_EFFECT_STATIC(FX_MODE_TWINKLEUP, mode_twinkleup, _data_FX_MODE_TWINKLEUP);
+  ADD_EFFECT_STATIC(FX_MODE_NOISEPAL, mode_noisepal, _data_FX_MODE_NOISEPAL);
+  ADD_EFFECT_STATIC(FX_MODE_SINEWAVE, mode_sinewave, _data_FX_MODE_SINEWAVE);
+  ADD_EFFECT_STATIC(FX_MODE_PHASEDNOISE, mode_phased_noise, _data_FX_MODE_PHASEDNOISE);
+  ADD_EFFECT_STATIC(FX_MODE_FLOW, mode_flow, _data_FX_MODE_FLOW);
+  ADD_EFFECT_STATIC(FX_MODE_CHUNCHUN, mode_chunchun, _data_FX_MODE_CHUNCHUN);  
+  ADD_EFFECT_STATIC(FX_MODE_WASHING_MACHINE, mode_washing_machine, _data_FX_MODE_WASHING_MACHINE);
+  ADD_EFFECT_STATIC(FX_MODE_BLENDS, mode_blends, _data_FX_MODE_BLENDS);
+  ADD_EFFECT_STATIC(FX_MODE_TV_SIMULATOR, mode_tv_simulator, _data_FX_MODE_TV_SIMULATOR);
+  ADD_EFFECT_STATIC(FX_MODE_DYNAMIC_SMOOTH, mode_dynamic_smooth, _data_FX_MODE_DYNAMIC_SMOOTH);
 
   // --- 1D audio effects ---
-  addEffect(FX_MODE_PIXELS, &mode_pixels, _data_FX_MODE_PIXELS);
-  addEffect(FX_MODE_PIXELWAVE, &mode_pixelwave, _data_FX_MODE_PIXELWAVE);
-  addEffect(FX_MODE_JUGGLES, &mode_juggles, _data_FX_MODE_JUGGLES);
-  addEffect(FX_MODE_MATRIPIX, &mode_matripix, _data_FX_MODE_MATRIPIX);
-  addEffect(FX_MODE_GRAVIMETER, &mode_gravimeter, _data_FX_MODE_GRAVIMETER);
-  addEffect(FX_MODE_PLASMOID, &mode_plasmoid, _data_FX_MODE_PLASMOID);
-  addEffect(FX_MODE_PUDDLES, &mode_puddles, _data_FX_MODE_PUDDLES);
-  addEffect(FX_MODE_MIDNOISE, &mode_midnoise, _data_FX_MODE_MIDNOISE);
-  addEffect(FX_MODE_NOISEMETER, &mode_noisemeter, _data_FX_MODE_NOISEMETER);
-  addEffect(FX_MODE_FREQWAVE, &mode_freqwave, _data_FX_MODE_FREQWAVE);
-  addEffect(FX_MODE_FREQMATRIX, &mode_freqmatrix, _data_FX_MODE_FREQMATRIX);
-  addEffect(FX_MODE_WATERFALL, &mode_waterfall, _data_FX_MODE_WATERFALL);
-  addEffect(FX_MODE_FREQPIXELS, &mode_freqpixels, _data_FX_MODE_FREQPIXELS);
-  addEffect(FX_MODE_NOISEFIRE, &mode_noisefire, _data_FX_MODE_NOISEFIRE);
-  addEffect(FX_MODE_PUDDLEPEAK, &mode_puddlepeak, _data_FX_MODE_PUDDLEPEAK);
-  addEffect(FX_MODE_NOISEMOVE, &mode_noisemove, _data_FX_MODE_NOISEMOVE);
-  addEffect(FX_MODE_PERLINMOVE, &mode_perlinmove, _data_FX_MODE_PERLINMOVE);
-  addEffect(FX_MODE_RIPPLEPEAK, &mode_ripplepeak, _data_FX_MODE_RIPPLEPEAK);
-  addEffect(FX_MODE_FREQMAP, &mode_freqmap, _data_FX_MODE_FREQMAP);
-  addEffect(FX_MODE_GRAVCENTER, &mode_gravcenter, _data_FX_MODE_GRAVCENTER);
-  addEffect(FX_MODE_GRAVCENTRIC, &mode_gravcentric, _data_FX_MODE_GRAVCENTRIC);
-  addEffect(FX_MODE_GRAVFREQ, &mode_gravfreq, _data_FX_MODE_GRAVFREQ);
-  addEffect(FX_MODE_DJLIGHT, &mode_DJLight, _data_FX_MODE_DJLIGHT);
-  addEffect(FX_MODE_BLURZ, &mode_blurz, _data_FX_MODE_BLURZ);
-  addEffect(FX_MODE_FLOWSTRIPE, &mode_FlowStripe, _data_FX_MODE_FLOWSTRIPE);
-  addEffect(FX_MODE_WAVESINS, &mode_wavesins, _data_FX_MODE_WAVESINS);
-  addEffect(FX_MODE_ROCKTAVES, &mode_rocktaves, _data_FX_MODE_ROCKTAVES);
-  addEffect(FX_MODE_SHIMMER, &mode_shimmer, _data_FX_MODE_SHIMMER);
+  ADD_EFFECT_STATIC(FX_MODE_PIXELS, mode_pixels, _data_FX_MODE_PIXELS);
+  ADD_EFFECT_STATIC(FX_MODE_PIXELWAVE, mode_pixelwave, _data_FX_MODE_PIXELWAVE);
+  ADD_EFFECT_STATIC(FX_MODE_JUGGLES, mode_juggles, _data_FX_MODE_JUGGLES);
+  ADD_EFFECT_STATIC(FX_MODE_MATRIPIX, mode_matripix, _data_FX_MODE_MATRIPIX);
+  ADD_EFFECT_STATIC(FX_MODE_GRAVIMETER, mode_gravimeter, _data_FX_MODE_GRAVIMETER);
+  ADD_EFFECT_STATIC(FX_MODE_PLASMOID, mode_plasmoid, _data_FX_MODE_PLASMOID);
+  ADD_EFFECT_STATIC(FX_MODE_PUDDLES, mode_puddles, _data_FX_MODE_PUDDLES);
+  ADD_EFFECT_STATIC(FX_MODE_MIDNOISE, mode_midnoise, _data_FX_MODE_MIDNOISE);
+  ADD_EFFECT_STATIC(FX_MODE_NOISEMETER, mode_noisemeter, _data_FX_MODE_NOISEMETER);
+  ADD_EFFECT_STATIC(FX_MODE_FREQWAVE, mode_freqwave, _data_FX_MODE_FREQWAVE);
+  ADD_EFFECT_STATIC(FX_MODE_FREQMATRIX, mode_freqmatrix, _data_FX_MODE_FREQMATRIX);
+  ADD_EFFECT_STATIC(FX_MODE_WATERFALL, mode_waterfall, _data_FX_MODE_WATERFALL);
+  ADD_EFFECT_STATIC(FX_MODE_FREQPIXELS, mode_freqpixels, _data_FX_MODE_FREQPIXELS);
+  ADD_EFFECT_STATIC(FX_MODE_NOISEFIRE, mode_noisefire, _data_FX_MODE_NOISEFIRE);
+  ADD_EFFECT_STATIC(FX_MODE_PUDDLEPEAK, mode_puddlepeak, _data_FX_MODE_PUDDLEPEAK);
+  ADD_EFFECT_STATIC(FX_MODE_NOISEMOVE, mode_noisemove, _data_FX_MODE_NOISEMOVE);
+  ADD_EFFECT_STATIC(FX_MODE_PERLINMOVE, mode_perlinmove, _data_FX_MODE_PERLINMOVE);
+  ADD_EFFECT_STATIC(FX_MODE_RIPPLEPEAK, mode_ripplepeak, _data_FX_MODE_RIPPLEPEAK);
+  ADD_EFFECT_STATIC(FX_MODE_FREQMAP, mode_freqmap, _data_FX_MODE_FREQMAP);
+  ADD_EFFECT_STATIC(FX_MODE_GRAVCENTER, mode_gravcenter, _data_FX_MODE_GRAVCENTER);
+  ADD_EFFECT_STATIC(FX_MODE_GRAVCENTRIC, mode_gravcentric, _data_FX_MODE_GRAVCENTRIC);
+  ADD_EFFECT_STATIC(FX_MODE_GRAVFREQ, mode_gravfreq, _data_FX_MODE_GRAVFREQ);
+  ADD_EFFECT_STATIC(FX_MODE_DJLIGHT, mode_DJLight, _data_FX_MODE_DJLIGHT);
+  ADD_EFFECT_STATIC(FX_MODE_BLURZ, mode_blurz, _data_FX_MODE_BLURZ);
+  ADD_EFFECT_STATIC(FX_MODE_FLOWSTRIPE, mode_FlowStripe, _data_FX_MODE_FLOWSTRIPE);
+  ADD_EFFECT_STATIC(FX_MODE_WAVESINS, mode_wavesins, _data_FX_MODE_WAVESINS);
+  ADD_EFFECT_STATIC(FX_MODE_ROCKTAVES, mode_rocktaves, _data_FX_MODE_ROCKTAVES);
+  ADD_EFFECT_STATIC(FX_MODE_SHIMMER, mode_shimmer, _data_FX_MODE_SHIMMER);
 
   // --- 2D  effects ---
 #ifndef WLED_DISABLE_2D
-  addEffect(FX_MODE_2DPLASMAROTOZOOM, &mode_2Dplasmarotozoom, _data_FX_MODE_2DPLASMAROTOZOOM);
-  addEffect(FX_MODE_2DSPACESHIPS, &mode_2Dspaceships, _data_FX_MODE_2DSPACESHIPS);
-  addEffect(FX_MODE_2DCRAZYBEES, &mode_2Dcrazybees, _data_FX_MODE_2DCRAZYBEES);
+  ADD_EFFECT_STATIC(FX_MODE_2DPLASMAROTOZOOM, mode_2Dplasmarotozoom, _data_FX_MODE_2DPLASMAROTOZOOM);
+  ADD_EFFECT_STATIC(FX_MODE_2DSPACESHIPS, mode_2Dspaceships, _data_FX_MODE_2DSPACESHIPS);
+  ADD_EFFECT_STATIC(FX_MODE_2DCRAZYBEES, mode_2Dcrazybees, _data_FX_MODE_2DCRAZYBEES);
 
   #ifdef WLED_PS_DONT_REPLACE_FX
-  addEffect(FX_MODE_2DGHOSTRIDER, &mode_2Dghostrider, _data_FX_MODE_2DGHOSTRIDER);
-  addEffect(FX_MODE_2DBLOBS, &mode_2Dfloatingblobs, _data_FX_MODE_2DBLOBS);
+  ADD_EFFECT_STATIC(FX_MODE_2DGHOSTRIDER, mode_2Dghostrider, _data_FX_MODE_2DGHOSTRIDER);
+  ADD_EFFECT_STATIC(FX_MODE_2DBLOBS, mode_2Dfloatingblobs, _data_FX_MODE_2DBLOBS);
   #endif
 
-  addEffect(FX_MODE_2DSCROLLTEXT, &mode_2Dscrollingtext, _data_FX_MODE_2DSCROLLTEXT);
-  addEffect(FX_MODE_2DDRIFTROSE, &mode_2Ddriftrose, _data_FX_MODE_2DDRIFTROSE);
-  addEffect(FX_MODE_2DDISTORTIONWAVES, &mode_2Ddistortionwaves, _data_FX_MODE_2DDISTORTIONWAVES);
-  addEffect(FX_MODE_2DGEQ, &mode_2DGEQ, _data_FX_MODE_2DGEQ); // audio
-  addEffect(FX_MODE_2DNOISE, &mode_2Dnoise, _data_FX_MODE_2DNOISE);
-  addEffect(FX_MODE_2DFIRENOISE, &mode_2Dfirenoise, _data_FX_MODE_2DFIRENOISE);
-  addEffect(FX_MODE_2DSQUAREDSWIRL, &mode_2Dsquaredswirl, _data_FX_MODE_2DSQUAREDSWIRL);
+  ADD_EFFECT_STATIC(FX_MODE_2DSCROLLTEXT, mode_2Dscrollingtext, _data_FX_MODE_2DSCROLLTEXT);
+  ADD_EFFECT_STATIC(FX_MODE_2DDRIFTROSE, mode_2Ddriftrose, _data_FX_MODE_2DDRIFTROSE);
+  ADD_EFFECT_STATIC(FX_MODE_2DDISTORTIONWAVES, mode_2Ddistortionwaves, _data_FX_MODE_2DDISTORTIONWAVES);
+  ADD_EFFECT_STATIC(FX_MODE_2DGEQ, mode_2DGEQ, _data_FX_MODE_2DGEQ); // audio
+  ADD_EFFECT_STATIC(FX_MODE_2DNOISE, mode_2Dnoise, _data_FX_MODE_2DNOISE);
+  ADD_EFFECT_STATIC(FX_MODE_2DFIRENOISE, mode_2Dfirenoise, _data_FX_MODE_2DFIRENOISE);
+  ADD_EFFECT_STATIC(FX_MODE_2DSQUAREDSWIRL, mode_2Dsquaredswirl, _data_FX_MODE_2DSQUAREDSWIRL);
 
   //non audio
-  addEffect(FX_MODE_2DDNA, &mode_2Ddna, _data_FX_MODE_2DDNA);
-  addEffect(FX_MODE_2DMATRIX, &mode_2Dmatrix, _data_FX_MODE_2DMATRIX);
-  addEffect(FX_MODE_2DMETABALLS, &mode_2Dmetaballs, _data_FX_MODE_2DMETABALLS);
-  addEffect(FX_MODE_2DFUNKYPLANK, &mode_2DFunkyPlank, _data_FX_MODE_2DFUNKYPLANK); // audio
-  addEffect(FX_MODE_2DPULSER, &mode_2DPulser, _data_FX_MODE_2DPULSER);
-  addEffect(FX_MODE_2DDRIFT, &mode_2DDrift, _data_FX_MODE_2DDRIFT);
-  addEffect(FX_MODE_2DWAVERLY, &mode_2DWaverly, _data_FX_MODE_2DWAVERLY); // audio
-  addEffect(FX_MODE_2DSUNRADIATION, &mode_2DSunradiation, _data_FX_MODE_2DSUNRADIATION);
-  addEffect(FX_MODE_2DCOLOREDBURSTS, &mode_2DColoredBursts, _data_FX_MODE_2DCOLOREDBURSTS);
-  addEffect(FX_MODE_2DJULIA, &mode_2DJulia, _data_FX_MODE_2DJULIA);
-  addEffect(FX_MODE_2DGAMEOFLIFE, &mode_2Dgameoflife, _data_FX_MODE_2DGAMEOFLIFE);
-  addEffect(FX_MODE_2DTARTAN, &mode_2Dtartan, _data_FX_MODE_2DTARTAN);
-  addEffect(FX_MODE_2DPOLARLIGHTS, &mode_2DPolarLights, _data_FX_MODE_2DPOLARLIGHTS);
-  addEffect(FX_MODE_2DSWIRL, &mode_2DSwirl, _data_FX_MODE_2DSWIRL); // audio
-  addEffect(FX_MODE_2DLISSAJOUS, &mode_2DLissajous, _data_FX_MODE_2DLISSAJOUS);
-  addEffect(FX_MODE_2DFRIZZLES, &mode_2DFrizzles, _data_FX_MODE_2DFRIZZLES);
-  addEffect(FX_MODE_2DPLASMABALL, &mode_2DPlasmaball, _data_FX_MODE_2DPLASMABALL);
-  addEffect(FX_MODE_2DHIPHOTIC, &mode_2DHiphotic, _data_FX_MODE_2DHIPHOTIC);
-  addEffect(FX_MODE_2DSINDOTS, &mode_2DSindots, _data_FX_MODE_2DSINDOTS);
-  addEffect(FX_MODE_2DDNASPIRAL, &mode_2DDNASpiral, _data_FX_MODE_2DDNASPIRAL);
-  addEffect(FX_MODE_2DBLACKHOLE, &mode_2DBlackHole, _data_FX_MODE_2DBLACKHOLE);
-  addEffect(FX_MODE_2DSOAP, &mode_2Dsoap, _data_FX_MODE_2DSOAP);
-  addEffect(FX_MODE_2DOCTOPUS, &mode_2Doctopus, _data_FX_MODE_2DOCTOPUS);
-  addEffect(FX_MODE_2DWAVINGCELL, &mode_2Dwavingcell, _data_FX_MODE_2DWAVINGCELL);
-  addEffect(FX_MODE_2DAKEMI, &mode_2DAkemi, _data_FX_MODE_2DAKEMI); // audio
+  ADD_EFFECT_STATIC(FX_MODE_2DDNA, mode_2Ddna, _data_FX_MODE_2DDNA);
+  ADD_EFFECT_STATIC(FX_MODE_2DMATRIX, mode_2Dmatrix, _data_FX_MODE_2DMATRIX);
+  ADD_EFFECT_STATIC(FX_MODE_2DMETABALLS, mode_2Dmetaballs, _data_FX_MODE_2DMETABALLS);
+  ADD_EFFECT_STATIC(FX_MODE_2DFUNKYPLANK, mode_2DFunkyPlank, _data_FX_MODE_2DFUNKYPLANK); // audio
+  ADD_EFFECT_STATIC(FX_MODE_2DPULSER, mode_2DPulser, _data_FX_MODE_2DPULSER);
+  ADD_EFFECT_STATIC(FX_MODE_2DDRIFT, mode_2DDrift, _data_FX_MODE_2DDRIFT);
+  ADD_EFFECT_STATIC(FX_MODE_2DWAVERLY, mode_2DWaverly, _data_FX_MODE_2DWAVERLY); // audio
+  ADD_EFFECT_STATIC(FX_MODE_2DSUNRADIATION, mode_2DSunradiation, _data_FX_MODE_2DSUNRADIATION);
+  ADD_EFFECT_STATIC(FX_MODE_2DCOLOREDBURSTS, mode_2DColoredBursts, _data_FX_MODE_2DCOLOREDBURSTS);
+  ADD_EFFECT_STATIC(FX_MODE_2DJULIA, mode_2DJulia, _data_FX_MODE_2DJULIA);
+  ADD_EFFECT_STATIC(FX_MODE_2DGAMEOFLIFE, mode_2Dgameoflife, _data_FX_MODE_2DGAMEOFLIFE);
+  ADD_EFFECT_STATIC(FX_MODE_2DTARTAN, mode_2Dtartan, _data_FX_MODE_2DTARTAN);
+  ADD_EFFECT_STATIC(FX_MODE_2DPOLARLIGHTS, mode_2DPolarLights, _data_FX_MODE_2DPOLARLIGHTS);
+  ADD_EFFECT_STATIC(FX_MODE_2DSWIRL, mode_2DSwirl, _data_FX_MODE_2DSWIRL); // audio
+  ADD_EFFECT_STATIC(FX_MODE_2DLISSAJOUS, mode_2DLissajous, _data_FX_MODE_2DLISSAJOUS);
+  ADD_EFFECT_STATIC(FX_MODE_2DFRIZZLES, mode_2DFrizzles, _data_FX_MODE_2DFRIZZLES);
+  ADD_EFFECT_STATIC(FX_MODE_2DPLASMABALL, mode_2DPlasmaball, _data_FX_MODE_2DPLASMABALL);
+  ADD_EFFECT_STATIC(FX_MODE_2DHIPHOTIC, mode_2DHiphotic, _data_FX_MODE_2DHIPHOTIC);
+  ADD_EFFECT_STATIC(FX_MODE_2DSINDOTS, mode_2DSindots, _data_FX_MODE_2DSINDOTS);
+  ADD_EFFECT_STATIC(FX_MODE_2DDNASPIRAL, mode_2DDNASpiral, _data_FX_MODE_2DDNASPIRAL);
+  ADD_EFFECT_STATIC(FX_MODE_2DBLACKHOLE, mode_2DBlackHole, _data_FX_MODE_2DBLACKHOLE);
+  ADD_EFFECT_STATIC(FX_MODE_2DSOAP, mode_2Dsoap, _data_FX_MODE_2DSOAP);
+  ADD_EFFECT_STATIC(FX_MODE_2DOCTOPUS, mode_2Doctopus, _data_FX_MODE_2DOCTOPUS);
+  ADD_EFFECT_STATIC(FX_MODE_2DWAVINGCELL, mode_2Dwavingcell, _data_FX_MODE_2DWAVINGCELL);
+  ADD_EFFECT_STATIC(FX_MODE_2DAKEMI, mode_2DAkemi, _data_FX_MODE_2DAKEMI); // audio
 
 #ifndef WLED_DISABLE_PARTICLESYSTEM2D
-  addEffect(FX_MODE_PARTICLEVOLCANO, &mode_particlevolcano, _data_FX_MODE_PARTICLEVOLCANO);
-  addEffect(FX_MODE_PARTICLEFIRE, &mode_particlefire, _data_FX_MODE_PARTICLEFIRE);
-  addEffect(FX_MODE_PARTICLEFIREWORKS, &mode_particlefireworks, _data_FX_MODE_PARTICLEFIREWORKS);
-  addEffect(FX_MODE_PARTICLEVORTEX, &mode_particlevortex, _data_FX_MODE_PARTICLEVORTEX);
-  addEffect(FX_MODE_PARTICLEPERLIN, &mode_particleperlin, _data_FX_MODE_PARTICLEPERLIN);
-  addEffect(FX_MODE_PARTICLEPIT, &mode_particlepit, _data_FX_MODE_PARTICLEPIT);
-  addEffect(FX_MODE_PARTICLEBOX, &mode_particlebox, _data_FX_MODE_PARTICLEBOX);
-  addEffect(FX_MODE_PARTICLEATTRACTOR, &mode_particleattractor, _data_FX_MODE_PARTICLEATTRACTOR); // 872 bytes
-  addEffect(FX_MODE_PARTICLEIMPACT, &mode_particleimpact, _data_FX_MODE_PARTICLEIMPACT);
-  addEffect(FX_MODE_PARTICLEWATERFALL, &mode_particlewaterfall, _data_FX_MODE_PARTICLEWATERFALL);
-  addEffect(FX_MODE_PARTICLESPRAY, &mode_particlespray, _data_FX_MODE_PARTICLESPRAY);
-  addEffect(FX_MODE_PARTICLESGEQ, &mode_particleGEQ, _data_FX_MODE_PARTICLEGEQ);
-  addEffect(FX_MODE_PARTICLECENTERGEQ, &mode_particlecenterGEQ, _data_FX_MODE_PARTICLECIRCULARGEQ);
-  addEffect(FX_MODE_PARTICLEGHOSTRIDER, &mode_particleghostrider, _data_FX_MODE_PARTICLEGHOSTRIDER);
-  addEffect(FX_MODE_PARTICLEBLOBS, &mode_particleblobs, _data_FX_MODE_PARTICLEBLOBS);
-  addEffect(FX_MODE_PARTICLEGALAXY, &mode_particlegalaxy, _data_FX_MODE_PARTICLEGALAXY);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEVOLCANO, mode_particlevolcano, _data_FX_MODE_PARTICLEVOLCANO);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEFIRE, mode_particlefire, _data_FX_MODE_PARTICLEFIRE);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEFIREWORKS, mode_particlefireworks, _data_FX_MODE_PARTICLEFIREWORKS);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEVORTEX, mode_particlevortex, _data_FX_MODE_PARTICLEVORTEX);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEPERLIN, mode_particleperlin, _data_FX_MODE_PARTICLEPERLIN);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEPIT, mode_particlepit, _data_FX_MODE_PARTICLEPIT);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEBOX, mode_particlebox, _data_FX_MODE_PARTICLEBOX);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEATTRACTOR, mode_particleattractor, _data_FX_MODE_PARTICLEATTRACTOR); // 872 bytes
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEIMPACT, mode_particleimpact, _data_FX_MODE_PARTICLEIMPACT);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEWATERFALL, mode_particlewaterfall, _data_FX_MODE_PARTICLEWATERFALL);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLESPRAY, mode_particlespray, _data_FX_MODE_PARTICLESPRAY);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLESGEQ, mode_particleGEQ, _data_FX_MODE_PARTICLEGEQ);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLECENTERGEQ, mode_particlecenterGEQ, _data_FX_MODE_PARTICLECIRCULARGEQ);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEGHOSTRIDER, mode_particleghostrider, _data_FX_MODE_PARTICLEGHOSTRIDER);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEBLOBS, mode_particleblobs, _data_FX_MODE_PARTICLEBLOBS);
+  ADD_EFFECT_STATIC(FX_MODE_PARTICLEGALAXY, mode_particlegalaxy, _data_FX_MODE_PARTICLEGALAXY);
 #endif // WLED_DISABLE_PARTICLESYSTEM2D
 #endif // WLED_DISABLE_2D
 
 #ifndef WLED_DISABLE_PARTICLESYSTEM1D
-addEffect(FX_MODE_PSDRIP, &mode_particleDrip, _data_FX_MODE_PARTICLEDRIP);
-addEffect(FX_MODE_PSPINBALL, &mode_particlePinball, _data_FX_MODE_PSPINBALL); //potential replacement for: bouncing balls, rollingballs, popcorn
-addEffect(FX_MODE_PSDANCINGSHADOWS, &mode_particleDancingShadows, _data_FX_MODE_PARTICLEDANCINGSHADOWS);
-addEffect(FX_MODE_PSFIREWORKS1D, &mode_particleFireworks1D, _data_FX_MODE_PS_FIREWORKS1D);
-addEffect(FX_MODE_PSSPARKLER, &mode_particleSparkler, _data_FX_MODE_PS_SPARKLER);
-addEffect(FX_MODE_PSHOURGLASS, &mode_particleHourglass, _data_FX_MODE_PS_HOURGLASS);
-addEffect(FX_MODE_PS1DSPRAY, &mode_particle1Dspray, _data_FX_MODE_PS_1DSPRAY);
-addEffect(FX_MODE_PSBALANCE, &mode_particleBalance, _data_FX_MODE_PS_BALANCE);
-addEffect(FX_MODE_PSCHASE, &mode_particleChase, _data_FX_MODE_PS_CHASE);
-addEffect(FX_MODE_PSSTARBURST, &mode_particleStarburst, _data_FX_MODE_PS_STARBURST);
-addEffect(FX_MODE_PS1DGEQ, &mode_particle1DGEQ, _data_FX_MODE_PS_1D_GEQ);
-addEffect(FX_MODE_PSFIRE1D, &mode_particleFire1D, _data_FX_MODE_PS_FIRE1D);
-addEffect(FX_MODE_PS1DSONICSTREAM, &mode_particle1DsonicStream, _data_FX_MODE_PS_SONICSTREAM);
-addEffect(FX_MODE_PS1DSONICBOOM, &mode_particle1DsonicBoom, _data_FX_MODE_PS_SONICBOOM);
-addEffect(FX_MODE_PS1DSPRINGY, &mode_particleSpringy, _data_FX_MODE_PS_SPRINGY);
+ADD_EFFECT_STATIC(FX_MODE_PSDRIP, mode_particleDrip, _data_FX_MODE_PARTICLEDRIP);
+ADD_EFFECT_STATIC(FX_MODE_PSPINBALL, mode_particlePinball, _data_FX_MODE_PSPINBALL); //potential replacement for: bouncing balls, rollingballs, popcorn
+ADD_EFFECT_STATIC(FX_MODE_PSDANCINGSHADOWS, mode_particleDancingShadows, _data_FX_MODE_PARTICLEDANCINGSHADOWS);
+ADD_EFFECT_STATIC(FX_MODE_PSFIREWORKS1D, mode_particleFireworks1D, _data_FX_MODE_PS_FIREWORKS1D);
+ADD_EFFECT_STATIC(FX_MODE_PSSPARKLER, mode_particleSparkler, _data_FX_MODE_PS_SPARKLER);
+ADD_EFFECT_STATIC(FX_MODE_PSHOURGLASS, mode_particleHourglass, _data_FX_MODE_PS_HOURGLASS);
+ADD_EFFECT_STATIC(FX_MODE_PS1DSPRAY, mode_particle1Dspray, _data_FX_MODE_PS_1DSPRAY);
+ADD_EFFECT_STATIC(FX_MODE_PSBALANCE, mode_particleBalance, _data_FX_MODE_PS_BALANCE);
+ADD_EFFECT_STATIC(FX_MODE_PSCHASE, mode_particleChase, _data_FX_MODE_PS_CHASE);
+ADD_EFFECT_STATIC(FX_MODE_PSSTARBURST, mode_particleStarburst, _data_FX_MODE_PS_STARBURST);
+ADD_EFFECT_STATIC(FX_MODE_PS1DGEQ, mode_particle1DGEQ, _data_FX_MODE_PS_1D_GEQ);
+ADD_EFFECT_STATIC(FX_MODE_PSFIRE1D, mode_particleFire1D, _data_FX_MODE_PS_FIRE1D);
+ADD_EFFECT_STATIC(FX_MODE_PS1DSONICSTREAM, mode_particle1DsonicStream, _data_FX_MODE_PS_SONICSTREAM);
+ADD_EFFECT_STATIC(FX_MODE_PS1DSONICBOOM, mode_particle1DsonicBoom, _data_FX_MODE_PS_SONICBOOM);
+ADD_EFFECT_STATIC(FX_MODE_PS1DSPRINGY, mode_particleSpringy, _data_FX_MODE_PS_SPRINGY);
 #endif // WLED_DISABLE_PARTICLESYSTEM1D
 
 }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -441,7 +441,7 @@ struct Effect {
   uint8_t id;   // mode (effect) id for legacy table (this may later be moved elsewhere)    
 
   public:
-  Effect(const char* data_, effect_function fcn_, uint8_t id_ = 255) : data(data_), fcn(fcn_), id(id_) {};
+  constexpr Effect(const char* data_, effect_function fcn_, uint8_t id_ = 255) : data(data_), fcn(fcn_), id(id_) {};
 };
 
 // Global effect list

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -427,7 +427,7 @@ namespace Effects { uint8_t getIdForEffect(const Effect*); };
 // Effect information structure
 typedef uint16_t (*effect_function)(); // pointer to mode function
 struct Effect {
-  const char *data; // mode (effect) name and its UI control data  
+  const char *data; // mode (effect) name and its UI control data
   effect_function    fcn;  // mode (effect) function
   /* Future: per-effect constructor function pointer goes here */
 
@@ -451,7 +451,10 @@ namespace Effects {
   void addEffect(const Effect* effect);     // add an effect to the global list
   uint8_t addEffect(const char *mode_name, effect_function mode_fn, uint8_t id);  // Add a non-static effect to the list; returns id
   
-  const Effect* getEffectByName(const char* name);
+  const Effect* getEffectByName(const char* name, size_t name_len);
+  inline const Effect* getEffectByName(const char* name) { return getEffectByName(name, strlen(name)); }
+  inline const Effect* getEffectByName(const String& name) { return getEffectByName(name.c_str(), name.length()); }
+
   const Effect* getEffectById(uint8_t id);    // Returns an effect pointer by id number; if not found, returns first effect
   inline uint8_t getIdForEffect(const Effect* effect) { return effect->id; }   // Returns the ID number assigned to an effect, or 255 if none available
   uint8_t getHighestId(); // Returns the highest assigned ID value; often used by older code to iterate through fx by id
@@ -724,7 +727,8 @@ class Segment {
     Segment &setCCT(uint16_t k);
     Segment &setOpacity(uint8_t o);
     Segment &setOption(uint8_t n, bool val);
-    Segment &setMode(uint8_t fx, bool loadDefaults = false);
+    Segment &setEffect(const Effect* effect, bool loadDefaults = false);
+    inline Segment &setMode(uint8_t fx, bool loadDefaults = false) { return setEffect(Effects::getEffectById(fx), loadDefaults); }
     Segment &setPalette(uint8_t pal);
     Segment &setName(const char* name);
     void    refreshLightCapabilities() const;

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -420,6 +420,56 @@ typedef enum mapping1D2D {
 
 class WS2812FX;
 
+// Forward declarations
+struct Effect;
+namespace Effects { uint8_t getIdForEffect(const Effect*); };
+
+// Effect information structure
+typedef uint16_t (*effect_function)(); // pointer to mode function
+struct Effect {
+  const char *data; // mode (effect) name and its UI control data  
+  effect_function    fcn;  // mode (effect) function
+  /* Future: per-effect constructor function pointer goes here */
+
+  // Parsed data accessors
+  String getName() const;
+  size_t getName(char* dest, size_t dest_size) const; // no-alloc retrieval
+
+  // ID being kept here right now is an implementation detail - use getIdForEffect() to retrieve
+  private:
+  friend uint8_t Effects::getIdForEffect(const Effect*);
+  uint8_t id;   // mode (effect) id for legacy table (this may later be moved elsewhere)    
+
+  public:
+  Effect(const char* data_, effect_function fcn_, uint8_t id_ = 255) : data(data_), fcn(fcn_), id(id_) {};
+};
+
+// Global effect list
+// FUTURE: the effect list could potentially be statically assembled at link time, like the usermod list; addEffect may become a macro
+namespace Effects {
+  void reserve(size_t);   // preallocate at least this much space for effect list
+  void addEffect(const Effect* effect);     // add an effect to the global list
+  uint8_t addEffect(const char *mode_name, effect_function mode_fn, uint8_t id);  // Add a non-static effect to the list; returns id
+  
+  const Effect* getEffectByName(const char* name);
+  const Effect* getEffectById(uint8_t id);    // Returns an effect pointer by id number; if not found, returns first effect
+  inline uint8_t getIdForEffect(const Effect* effect) { return effect->id; }   // Returns the ID number assigned to an effect, or 255 if none available
+  uint8_t getHighestId(); // Returns the highest assigned ID value; often used by older code to iterate through fx by id
+  
+  inline const char *getModeData(unsigned id = 0) { return getEffectById(id)->data; }
+
+  size_t getCount();
+  size_t getCapacity();
+  
+  // Range interface: for(auto& effect: Effects.all())
+  struct asRange {
+    std::vector<const Effect*>::iterator begin();
+    std::vector<const Effect*>::iterator end();
+  };
+  inline asRange all() { return asRange {}; }
+}
+
+
 // segment, 76 bytes
 class Segment {
   public:
@@ -449,7 +499,8 @@ class Segment {
     uint8_t  grouping, spacing;
     uint8_t  opacity,  cct;       // 0==1900K, 255==10091K
     // effect data
-    uint8_t  mode;
+    const Effect* effect;
+    [[deprecated("Use seg.effect for effect metadata, or Effects::getIdForEffect(Segment.effect) if you require a legacy numeric ID")]] uint8_t mode;
     uint8_t  palette;
     uint8_t  speed;
     uint8_t  intensity;
@@ -567,6 +618,8 @@ class Segment {
 
   public:
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     Segment(uint16_t sStart=0, uint16_t sStop=30, uint16_t sStartY = 0, uint16_t sStopY = 1)
     : colors{DEFAULT_COLOR,BLACK,BLACK}
     , start(sStart)
@@ -579,7 +632,8 @@ class Segment {
     , spacing(0)
     , opacity(255)
     , cct(127)
-    , mode(DEFAULT_MODE)
+    , effect(Effects::getEffectById(0))
+    , mode(0)
     , palette(0)
     , speed(DEFAULT_SPEED)
     , intensity(DEFAULT_INTENSITY)
@@ -612,6 +666,7 @@ class Segment {
         stop = 0; // mark segment as inactive/invalid
       }
     }
+#pragma GCC diagnostic pop
 
     Segment(const Segment &orig); // copy constructor
     Segment(Segment &&orig) noexcept; // move constructor
@@ -822,14 +877,7 @@ class Segment {
 
 // main "strip" class (108 bytes)
 class WS2812FX {
-  typedef uint16_t (*mode_ptr)(); // pointer to mode function
   typedef void (*show_callback)(); // pre show callback
-  typedef struct ModeData {
-    uint8_t     _id;   // mode (effect) id
-    mode_ptr    _fcn;  // mode (effect) function
-    const char *_data; // mode (effect) name and its UI control data
-    ModeData(uint8_t id, uint16_t (*fcn)(void), const char *data) : _id(id), _fcn(fcn), _data(data) {}
-  } mode_data_t;
 
   public:
 
@@ -861,29 +909,20 @@ class WS2812FX {
       _triggered(false),
       _segment_index(0),
       _mainSegment(0),
-      _modeCount(MODE_COUNT),
       _callback(nullptr),
       customMappingTable(nullptr),
       customMappingSize(0),
       _lastShow(0),
       _lastServiceShow(0)
     {
-      _mode.reserve(_modeCount);     // allocate memory to prevent initial fragmentation (does not increase size())
-      _modeData.reserve(_modeCount); // allocate memory to prevent initial fragmentation (does not increase size())
-      if (_mode.capacity() <= 1 || _modeData.capacity() <= 1) _modeCount = 1; // memory allocation failed only show Solid
-      else setupEffectData();
+      Effects::reserve(MODE_COUNT);     // allocate memory to prevent initial fragmentation (does not increase size())
+      setupEffectData();
     }
 
     ~WS2812FX() {
       p_free(_pixels);
       p_free(_pixelCCT); // just in case
       d_free(customMappingTable);
-      _mode.clear();
-      _modeData.clear();
-      _segments.clear();
-#ifndef WLED_DISABLE_2D
-      panel.clear();
-#endif
     }
 
     void
@@ -941,15 +980,13 @@ class WS2812FX {
     uint8_t getFirstSelectedSegId() const;
     uint8_t getLastActiveSegmentId() const;
     uint8_t getActiveSegsLightCapabilities(bool selectedOnly = false) const;
-    uint8_t addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name);         // add effect to the list; defined in FX.cpp;
-
+    
     inline uint8_t getBrightness() const    { return _brightness; }       // returns current strip brightness
     inline static constexpr unsigned getMaxSegments() { return MAX_NUM_SEGMENTS; }  // returns maximum number of supported segments (fixed value)
     inline uint8_t getSegmentsNum() const   { return _segments.size(); }  // returns currently present segments
     inline uint8_t getCurrSegmentId() const { return _segment_index; }    // returns current segment index (only valid while strip.isServicing())
     inline uint8_t getMainSegmentId() const { return _mainSegment; }      // returns main segment index
     inline uint8_t getTargetFps() const     { return _targetFps; }        // returns rough FPS value for las 2s interval
-    inline uint8_t getModeCount() const     { return _modeCount; }        // returns number of registered modes/effects
 
     uint16_t getLengthPhysical() const;
     uint16_t getLengthTotal() const; // will include virtual/nonexistent pixels in matrix
@@ -968,8 +1005,10 @@ class WS2812FX {
     inline uint32_t getPixelColor(unsigned n) const { return (n < getLengthTotal()) ? _pixels[n] : 0; } // returns color of pixel n
     inline uint32_t getLastShow() const             { return _lastShow; }                 // returns millis() timestamp of last strip.show() call
 
-    const char *getModeData(unsigned id = 0) const  { return (id && id < _modeCount) ? _modeData[id] : PSTR("Solid"); }
-    inline const char **getModeDataSrc()            { return &(_modeData[0]); }           // vectors use arrays for underlying data
+    // Shim interface to library of Effects for compatibility    
+    inline uint8_t addEffect(uint8_t id, effect_function mode_fn, const char *mode_name) { return Effects::addEffect(mode_name, mode_fn, id); }
+    inline const char *getModeData(unsigned id = 0) const { return Effects::getEffectById(id)->data; }
+    inline uint8_t getModeCount() const     { return Effects::getHighestId() + 1; }  // For iterating through Effects by ID - may be larger or smaller than the actual valid Effect count
 
     Segment&        getSegment(unsigned id);
     inline Segment& getFirstSelectedSeg() { return _segments[getFirstSelectedSegId()]; }  // returns reference to first segment that is "selected"
@@ -1048,10 +1087,6 @@ class WS2812FX {
     uint8_t _segment_index;
     uint8_t _mainSegment;
 
-    uint8_t                  _modeCount;
-    std::vector<mode_ptr>    _mode;     // SRAM footprint: 4 bytes per element
-    std::vector<const char*> _modeData; // mode (effect) name and its slider control data array
-
     show_callback _callback;
 
     uint16_t* customMappingTable;
@@ -1063,7 +1098,7 @@ class WS2812FX {
     friend class Segment;
 };
 
-extern const char JSON_mode_names[];
+constexpr const char* JSON_mode_names = nullptr;
 extern const char JSON_palette_names[];
 
 #endif

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -566,8 +566,7 @@ static int16_t extractEffectDefault(const char* data, const char *segVar)
   return atoi(stopPtr);
 }
 
-Segment &Segment::setMode(uint8_t fx, bool loadDefaults) {
-  const Effect* new_effect = Effects::getEffectById(fx);
+Segment &Segment::setEffect(const Effect* new_effect, bool loadDefaults) {
   if (effect != new_effect) {
     startTransition(strip.getTransition(), true); // set effect transitions (must create segment copy)
     effect = new_effect;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -228,7 +228,7 @@ void handleDMXData(uint16_t uni, uint16_t dmxChannels, uint8_t* e131_data, uint8
             return;
 
           if (e131_data[dataOffset+1] < strip.getModeCount())
-            if (e131_data[dataOffset+1] != seg.mode)      seg.setMode(   e131_data[dataOffset+1]);
+          if (e131_data[dataOffset+1] != Effects::getIdForEffect(seg.effect))      seg.setMode(   e131_data[dataOffset+1]);
           if (e131_data[dataOffset+2]   != seg.speed)     seg.speed     = e131_data[dataOffset+2];      
           if (e131_data[dataOffset+3]   != seg.intensity) seg.intensity = e131_data[dataOffset+3];
           if (e131_data[dataOffset+4]   != seg.palette)   seg.setPalette(e131_data[dataOffset+4]);

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -398,7 +398,6 @@ bool requestJSONBufferLock(uint8_t moduleID=255);
 void releaseJSONBufferLock();
 uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLen);
 uint8_t extractModeSlider(uint8_t mode, uint8_t slider, char *dest, uint8_t maxLen, uint8_t *var = nullptr);
-int16_t extractModeDefaults(uint8_t mode, const char *segVar);
 void checkSettingsPIN(const char *pin);
 uint16_t crc16(const unsigned char* data_p, size_t length);
 uint16_t beatsin88_t(accum88 beats_per_minute_88, uint16_t lowest = 0, uint16_t highest = 65535, uint32_t timebase = 0, uint16_t phase_offset = 0);

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -15,7 +15,7 @@ void setValuesFromSegment(uint8_t s) {
   colSec[1] = G(seg.colors[1]);
   colSec[2] = B(seg.colors[1]);
   colSec[3] = W(seg.colors[1]);
-  effectCurrent   = seg.mode;
+  effectCurrent   = Effects::getIdForEffect(seg.effect);
   effectSpeed     = seg.speed;
   effectIntensity = seg.intensity;
   effectPalette   = seg.palette;
@@ -30,7 +30,7 @@ void applyValuesToSelectedSegs() {
     if (effectSpeed     != seg.speed)     {seg.speed     = effectSpeed;     stateChanged = true;}
     if (effectIntensity != seg.intensity) {seg.intensity = effectIntensity; stateChanged = true;}
     if (effectPalette   != seg.palette)   {seg.setPalette(effectPalette);}
-    if (effectCurrent   != seg.mode)      {seg.setMode(effectCurrent);}
+    if (effectCurrent   != Effects::getIdForEffect(seg.effect))      {seg.setMode(effectCurrent);}
     uint32_t col0 = RGBW32(colPri[0], colPri[1], colPri[2], colPri[3]);
     uint32_t col1 = RGBW32(colSec[0], colSec[1], colSec[2], colSec[3]);
     if (col0 != seg.colors[0])            {seg.setColor(0, col0);}

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -93,7 +93,7 @@ void handleOverlayDraw() {
     for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
       const Segment& segment = strip.getSegment(i);
       if (!segment.isActive()) continue;
-      if (segment.mode > 0 || segment.colors[0] > 0) {
+      if (Effects::getIdForEffect(segment.effect) > 0 || segment.colors[0] > 0) {
         return;
       }
     }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -875,7 +875,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   uint32_t col2    = selseg.colors[2];
   byte colIn[4]    = {R(col0), G(col0), B(col0), W(col0)};
   byte colInSec[4] = {R(col1), G(col1), B(col1), W(col1)};
-  byte effectIn    = selseg.mode;
+  byte effectIn    = 0;
   byte speedIn     = selseg.speed;
   byte intensityIn = selseg.intensity;
   byte paletteIn   = selseg.palette;
@@ -1060,9 +1060,11 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   bool fxModeChanged = false, speedChanged = false, intensityChanged = false, paletteChanged = false;
   bool custom1Changed = false, custom2Changed = false, custom3Changed = false, check1Changed = false, check2Changed = false, check3Changed = false;
   // set effect parameters
-  if (updateVal(req.c_str(), "FX=", effectIn, 0, strip.getModeCount()-1)) {
-    if (request != nullptr) unloadPlaylist(); // unload playlist if changing FX using web request
-    fxModeChanged = true;
+  if (updateVal(req.c_str(), "FX=", effectIn, 0, 255)) {
+    if (Effects::getEffectById(effectIn) != selseg.effect) {
+      if (request != nullptr) unloadPlaylist(); // unload playlist if changing FX using web request
+      fxModeChanged = true;
+    }
   }
   speedChanged     = updateVal(req.c_str(), "SX=", speedIn);
   intensityChanged = updateVal(req.c_str(), "IX=", intensityIn);

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -48,7 +48,7 @@ void notify(byte callMode, bool followUp)
   udpOut[5] = B(col);
   udpOut[6] = nightlightActive;
   udpOut[7] = nightlightDelayMins;
-  udpOut[8] = mainseg.mode;
+  udpOut[8] = Effects::getIdForEffect(mainseg.effect);
   udpOut[9] = mainseg.speed;
   udpOut[10] = W(col);
   //compatibilityVersionByte:
@@ -118,7 +118,7 @@ void notify(byte callMode, bool followUp)
     udpOut[8 +ofs] = selseg.offset & 0xFF;
     udpOut[9 +ofs] = selseg.options & 0x8F; //only take into account selected, mirrored, on, reversed, reverse_y (for 2D); ignore freeze, reset, transitional
     udpOut[10+ofs] = selseg.opacity;
-    udpOut[11+ofs] = selseg.mode;
+    udpOut[11+ofs] = Effects::getIdForEffect(selseg.effect);
     udpOut[12+ofs] = selseg.speed;
     udpOut[13+ofs] = selseg.intensity;
     udpOut[14+ofs] = selseg.palette;


### PR DESCRIPTION
Pursuant to the ongoing discussions regarding handling large numbers of effects, this spike targets the core API changes I think set the most practical direction for future effect management.  The design intent is to preserve compatibility with existing APIs (up to the 255 effect limit), and open a way for new APIs to break that limitation with minimal disruption to existing integrations.

First, the internal upgrade:

The key API changes center around supporting "non-contiguous" effect IDs -- be it names, a paging system, a usermod indexing scheme, or whatever.  In all cases, the "effect identifier" is no longer strictly an index in to a vector.  To this end, I refactored the effect metadata to a new `struct Effect`, keeping all per-effect information (name, function, id) in one place, and built an interface that relies on using functions to look up the Effect entry by name or ID.

Internal API changes:
- New:
  - Adds new `struct Effect` to collect effect-related data in one place
  - Moves global list of effects from `class WS2812FX` to new `namespace Effects`
  - Add effect lookup functions `Effects::getEffectById()` or `Effects::getEffectByName()`.  Function implementations can be replaced or extended to support different indexing approaches (larger id type? numeric ID maps?) without breaking API compatibility.
- Changed:
  - Segments now use an `Effect*` to look up the function.
  - Mode-related API on WS2812FX now implemented by calling Effects namespace functions.
  - `Segment::mode` is preserved for API compatibility, but marked as deprecated.
- Removed:
  - `WS2812FX::getModeDataSrc()` was the one existing internal API that could not be trivially supported.  This impacted one usermod.

External API changes:
None.  (Or at least none intentionally; I might have missed a special case re "Solid"'s metadata (or lack thereof)).  Endpoints 'json/fxda' and 'json/eff' continue to return arrays where the index in to the array matches the 'getEffectById()' callback.  Those arrays remain limited to 255 entries to ensure strict compatibility.

---

From there, the external JSON API is expanded:
- New 'json/fxmap' endpoint returns a JSON object, where keys are the effect names, and the values objects of the form `{"info": "...", "id": id}`, where "id" is only present if the effect id is representable in a uint8_t.  This allows an arbitrarily long list of effects to be described to a client without gaps for unused IDs.
- JSON API now accepts `{"ef": "effect name"}` when deserializing a segment, and emits this key when serializing.  If "ef" and "fx" are both supplied, "ef" has precedence.

The following commit adapts the web UI to use this API instead of ids.   

---

The last commit saves some RAM by moving the Effect objects to code space.

---

Implementation notes:
- I have made no effort to optimize effect name/id lookup.  This does not matter to rendering as the Effect pointer is stored directly.  This could be added later to speed up some of the API calls.
- A `strnchr_P` function for ESP8266 would be nice.
  - or alternately, we could choose to store effect name and metadata in separate literals.  That might be a breaking API change though - I don't know if it's possible to `constexpr`-transform the existing literals at compile time.
  - Another alternative might be store the name length (calculated at compile time).
- Automatic "legacy" ID assignment is still performed for effects up to 255.  After that either names will still work; and the architecture permits us to easily expand the numeric ID data type and/or add some expanded ID space as a new API (pages, a configurable mapper, or all of the above).
- Functions to select a random effect, or "step through" effects, could be added to `namespace Effects`.  Current implementations of these features in various endpoints work by mutating IDs, which will be problematic if the ID space becomes sparse.
- The fxmap endpoint implementation either fits a whole effect in to a packet, or defers it for the next one.  This is an inefficient use of bandwidth: keeping a local line buffer would allow it to be more bandwidth friendly at the cost of more RAM usage.
- This implemention still keeps all `Effect*`s in a dynamically allocated vector.  A future design could also offer a compile-time static list, saving a bit more RAM.  The dynamic list could be kept (it's cost is small when empty) for compatibility with older APIs as well as providing a foundation to support runtime-defined effects (ARTI-FX or similar) as fully integrated members.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Effects are now identified and selected by name, improving consistency across the web interface and device integrations.
  * Added a consolidated effect map endpoint for retrieving effect names, IDs, and parameter information.
  * Effect metadata and default settings are handled more reliably across segments.

* **Bug Fixes**
  * Improved effect synchronization through DMX, UDP, playlists, overlays, and other controls.
  * Preserved compatibility with numeric effect selections while supporting the new name-based format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->