### PR TITLE
Implement individual control in WizLights Usermod

### DIFF
--- a/usermods/wizlights/wizlights.cpp
+++ b/usermods/wizlights/wizlights.cpp
@@ -15,8 +15,8 @@ class WizLightsUsermod : public Usermod {
     unsigned long lastTime = 0;
     long updateInterval;
     long sendDelay;
-    int ledOffset;
-    
+    uint16_t ledOffset;
+
     long forceUpdateMinutes;
     bool forceUpdate;
 
@@ -130,6 +130,13 @@ class WizLightsUsermod : public Usermod {
       bool configComplete = !top.isNull();
 
       configComplete &= getJsonValue(top["LED Offset"],                   ledOffset,          0);     // Offset the "address" of the Wiz Lights for individual control
+
+      if (ledOffset + MAX_WIZ_LIGHTS > strip.getLengthTotal())
+      {
+        ledOffset = 0;
+        configComplete = false;
+      }
+
       configComplete &= getJsonValue(top["Interval (ms)"],                updateInterval,     1000);  // How frequently to update the Wiz lights
       configComplete &= getJsonValue(top["Send Delay (ms)"],              sendDelay,          0);     // Optional delay after sending each UDP message
       configComplete &= getJsonValue(top["Use Enhanced White *"],         useEnhancedWhite,   false); // When color is white use Wiz white LEDs instead of mixing RGB

--- a/usermods/wizlights/wizlights.cpp
+++ b/usermods/wizlights/wizlights.cpp
@@ -91,7 +91,11 @@ class WizLightsUsermod : public Usermod {
         bool update = false;
         for (uint8_t i = 0; i < MAX_WIZ_LIGHTS; i++) {
           if (!lightsValid[i]) { continue; }
-          uint32_t newColor = strip.getPixelColor(i + ledOffset);
+
+          uint16_t pixelIndex = i + ledOffset;
+          if (pixelIndex >= strip.getLengthTotal()) continue;
+          uint32_t newColor = strip.getPixelColor(pixelIndex);
+
           if (forceUpdate || (newColor != colorsSent[i]) || (ellapsedTime > forceUpdateMinutes*60000)){
             wizSendColor(lightsIP[i], newColor);
             colorsSent[i] = newColor;

--- a/usermods/wizlights/wizlights.cpp
+++ b/usermods/wizlights/wizlights.cpp
@@ -15,6 +15,7 @@ class WizLightsUsermod : public Usermod {
     unsigned long lastTime = 0;
     long updateInterval;
     long sendDelay;
+    int ledOffset;
     
     long forceUpdateMinutes;
     bool forceUpdate;
@@ -90,7 +91,7 @@ class WizLightsUsermod : public Usermod {
         bool update = false;
         for (uint8_t i = 0; i < MAX_WIZ_LIGHTS; i++) {
           if (!lightsValid[i]) { continue; }
-          uint32_t newColor = strip.getPixelColor(i);
+          uint32_t newColor = strip.getPixelColor(i + ledOffset);
           if (forceUpdate || (newColor != colorsSent[i]) || (ellapsedTime > forceUpdateMinutes*60000)){
             wizSendColor(lightsIP[i], newColor);
             colorsSent[i] = newColor;
@@ -107,6 +108,7 @@ class WizLightsUsermod : public Usermod {
     void addToConfig(JsonObject& root)
     {
       JsonObject top = root.createNestedObject("wizLightsUsermod");
+      top["LED Offset"] = ledOffset;
       top["Interval (ms)"]                = updateInterval;
       top["Send Delay (ms)"]              = sendDelay;
       top["Use Enhanced White *"]         = useEnhancedWhite;
@@ -127,13 +129,14 @@ class WizLightsUsermod : public Usermod {
       JsonObject top = root["wizLightsUsermod"];
       bool configComplete = !top.isNull();
 
-      configComplete &= getJsonValue(top["Interval (ms)"],                updateInterval,     1000);  // How frequently to update the wiz lights
+      configComplete &= getJsonValue(top["LED Offset"],                   ledOffset,          0);     // Offset the "address" of the Wiz Lights for individual control
+      configComplete &= getJsonValue(top["Interval (ms)"],                updateInterval,     1000);  // How frequently to update the Wiz lights
       configComplete &= getJsonValue(top["Send Delay (ms)"],              sendDelay,          0);     // Optional delay after sending each UDP message
-      configComplete &= getJsonValue(top["Use Enhanced White *"],         useEnhancedWhite,   false); // When color is white use wiz white LEDs instead of mixing RGB
+      configComplete &= getJsonValue(top["Use Enhanced White *"],         useEnhancedWhite,   false); // When color is white use Wiz white LEDs instead of mixing RGB
       configComplete &= getJsonValue(top["* Warm White Value (0-255)"],   warmWhite,          0);     // Warm White LED value for Enhanced White
-      configComplete &= getJsonValue(top["* Cold White Value (0-255)"],   coldWhite,          50);   // Cold White LED value for Enhanced White
-      configComplete &= getJsonValue(top["Always Force Update"],          forceUpdate,        false); // Update wiz light every loop, even if color value has not changed
-      configComplete &= getJsonValue(top["Force Update Every x Minutes"], forceUpdateMinutes, 5);     // Update wiz light if color value has not changed, every x minutes
+      configComplete &= getJsonValue(top["* Cold White Value (0-255)"],   coldWhite,          50);    // Cold White LED value for Enhanced White
+      configComplete &= getJsonValue(top["Always Force Update"],          forceUpdate,        false); // Update Wiz light every loop, even if color value has not changed
+      configComplete &= getJsonValue(top["Force Update Every x Minutes"], forceUpdateMinutes, 5);     // Update Wiz light if color value has not changed, every x minutes
       
       // Read list of IPs
       String tempIp;


### PR DESCRIPTION
- Add LED Offset Configuration
  - Offset Wiz Lights from the first pixels to become individually controllable
  - MUST add _MAX_WIZ_LIGHTS_ to WLED output when **offset = output length**
 
**Added Configuration**
<img width="710" height="559" alt="image" src="https://github.com/user-attachments/assets/fe76c03a-3add-4fa8-a13e-911cfaa404a2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable LED offset to shift per‑light color addressing; offset is saved and loaded with settings.

* **Bug Fixes**
  * Validates offsets against strip length to prevent out‑of‑range updates and skipped lights when necessary.

* **Style**
  * Minor capitalization and wording adjustments in user-facing strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->