### PR TITLE
add multiple meteors and ability to slow meteors

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2424,12 +2424,11 @@ void mode_meteor() {
     unsigned start = (meteorstart + m * SEGLEN / numMeteors) % SEGLEN;
     for (unsigned j = 0; j < meteorSize; j++) {
       unsigned index = (start + j) % SEGLEN;
-      if(meteorSmooth) {
-          trail[index] = max;
-          uint32_t col = SEGMENT.check1 ? SEGMENT.color_from_palette(index, true, false, 0, trail[index]) : SEGMENT.color_from_palette(trail[index], false, true, 255);
-          SEGMENT.setPixelColor(index, col);
-      }
-      else{
+      if (meteorSmooth) {
+        trail[index] = max;
+        uint32_t col = SEGMENT.check1 ? SEGMENT.color_from_palette(index, true, false, 0, trail[index]) : SEGMENT.color_from_palette(trail[index], false, true, 255);
+        SEGMENT.setPixelColor(index, col);
+      } else {
         int idx = 255;
         int i = trail[index] = max;
         if (!SEGMENT.check1) {

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2383,6 +2383,10 @@ void mode_meteor() {
   byte* trail = SEGENV.data;
 
   const unsigned meteorSize = 1 + SEGLEN / 20; // 5%
+  if (SEGMENT.custom3 != 1) {
+    SEGMENT.custom1 = 0;
+    SEGMENT.custom3 = 1;
+  }
   const unsigned numMeteors = 1 + (SEGMENT.custom1 >> 5); // 1..8 meteors
   uint16_t meteorstart;
   if(meteorSmooth) meteorstart = map((SEGENV.step >> 6 & 0xFF), 0, 255, 0, SEGLEN -1);
@@ -2443,7 +2447,7 @@ void mode_meteor() {
 
   SEGENV.step += (slow ? SEGMENT.speed >> 3 : SEGMENT.speed) + 1;
 }
-static const char _data_FX_MODE_METEOR[] PROGMEM = "Meteor@!,Trail,# of Meteors,,,Gradient,Slow,Smooth;;!;1;c1=0";
+static const char _data_FX_MODE_METEOR[] PROGMEM = "Meteor@!,Trail,# of Meteors,,,Gradient,Slow,Smooth;;!;1;c1=0,c3=1";
 
 
 //Railway Crossing / Christmas Fairy lights

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2379,13 +2379,15 @@ void mode_meteor() {
   if (SEGLEN <= 1) FX_FALLBACK_STATIC;
   if (!SEGENV.allocateData(SEGLEN)) FX_FALLBACK_STATIC; //allocation failed
   const bool meteorSmooth = SEGMENT.check3;
+  const bool slow = SEGMENT.check2;
   byte* trail = SEGENV.data;
 
   const unsigned meteorSize = 1 + SEGLEN / 20; // 5%
+  const unsigned numMeteors = 1 + (SEGMENT.custom1 >> 5); // 1..8 meteors
   uint16_t meteorstart;
   if(meteorSmooth) meteorstart = map((SEGENV.step >> 6 & 0xFF), 0, 255, 0, SEGLEN -1);
   else {
-    unsigned counter = strip.now * ((SEGMENT.speed >> 2) + 8);
+    unsigned counter = strip.now * (slow ? (SEGMENT.speed >> 4) + 1 : (SEGMENT.speed >> 2) + 8);
     meteorstart = (counter * SEGLEN) >> 16;
   }
 
@@ -2417,29 +2419,32 @@ void mode_meteor() {
     }
   }
 
-  // draw meteor
-  for (unsigned j = 0; j < meteorSize; j++) {
-    unsigned index = (meteorstart + j) % SEGLEN;
-    if(meteorSmooth) {
-        trail[index] = max;
-        uint32_t col = SEGMENT.check1 ? SEGMENT.color_from_palette(index, true, false, 0, trail[index]) : SEGMENT.color_from_palette(trail[index], false, true, 255);
-        SEGMENT.setPixelColor(index, col);
-    }
-    else{
-      int idx = 255;
-      int i = trail[index] = max;
-      if (!SEGMENT.check1) {
-        i = map(index,0,SEGLEN,0,max);
-        idx = 0;
+  // draw meteor(s), evenly spaced along the strip
+  for (unsigned m = 0; m < numMeteors; m++) {
+    unsigned start = (meteorstart + m * SEGLEN / numMeteors) % SEGLEN;
+    for (unsigned j = 0; j < meteorSize; j++) {
+      unsigned index = (start + j) % SEGLEN;
+      if(meteorSmooth) {
+          trail[index] = max;
+          uint32_t col = SEGMENT.check1 ? SEGMENT.color_from_palette(index, true, false, 0, trail[index]) : SEGMENT.color_from_palette(trail[index], false, true, 255);
+          SEGMENT.setPixelColor(index, col);
       }
-      uint32_t col = SEGMENT.color_from_palette(i, false, false, idx, 255); // full brightness
-      SEGMENT.setPixelColor(index, col);
+      else{
+        int idx = 255;
+        int i = trail[index] = max;
+        if (!SEGMENT.check1) {
+          i = map(index,0,SEGLEN,0,max);
+          idx = 0;
+        }
+        uint32_t col = SEGMENT.color_from_palette(i, false, false, idx, 255); // full brightness
+        SEGMENT.setPixelColor(index, col);
+      }
     }
   }
 
-  SEGENV.step += SEGMENT.speed +1;
+  SEGENV.step += (slow ? SEGMENT.speed >> 3 : SEGMENT.speed) + 1;
 }
-static const char _data_FX_MODE_METEOR[] PROGMEM = "Meteor@!,Trail,,,,Gradient,,Smooth;;!;1";
+static const char _data_FX_MODE_METEOR[] PROGMEM = "Meteor@!,Trail,# of Meteors,,,Gradient,Slow,Smooth;;!;1;c1=0";
 
 
 //Railway Crossing / Christmas Fairy lights

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2383,11 +2383,16 @@ void mode_meteor() {
   byte* trail = SEGENV.data;
 
   const unsigned meteorSize = 1 + SEGLEN / 20; // 5%
+  // custom3 is not exposed as a slider; it doubles as a one-time init flag (default c3=1 in metadata).
+  // Legacy configs predating the "# of Meteors" control may carry a leftover custom1 value, which would
+  // render an unexpected meteor count. If custom3 is not 1, treat the config as legacy: reset custom1 to
+  // 0 (single meteor) and mark custom3=1 so this migration runs only once.
   if (SEGMENT.custom3 != 1) {
     SEGMENT.custom1 = 0;
     SEGMENT.custom3 = 1;
   }
-  const unsigned numMeteors = 1 + (SEGMENT.custom1 >> 5); // 1..8 meteors
+  // clamp to SEGLEN so meteors get distinct start indices on very short segments (avoids duplicates)
+  const unsigned numMeteors = min((unsigned)(1 + (SEGMENT.custom1 >> 5)), (unsigned)SEGLEN); // 1..8 meteors
   uint16_t meteorstart;
   if(meteorSmooth) meteorstart = map((SEGENV.step >> 6 & 0xFF), 0, 255, 0, SEGLEN -1);
   else {


### PR DESCRIPTION
I really like the "Meteor" effect, and wanted to have multiple meteors going across my house. So I added a slider that adds meteors (up to 8, default 1).

The meteors also moved very quickly across my house, so I added a checkbox function to slow the meteors down (default off).

Built and tested locally and works well.

AI was used to assist me coding this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Enhanced the Meteor effect to display multiple evenly spaced meteors.
  * Added a **Slow** mode for a more relaxed animation pace.
  * Added controls for the **# of Meteors** and **Slow** settings.

* **Improvements**
  * Improved meteor timing and trail behavior for smoother, more consistent rendering.
  * Adjusted animation handling for short segments to prevent overlapping meteor positions.
  * Preserved coordinated progression across all meteors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->