### PR TITLE
Encapsulate hue.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/hue.cpp
+++ b/wled00/hue.cpp
@@ -6,6 +6,18 @@
 
 #ifndef WLED_DISABLE_HUESYNC
 
+// Hue bridge sync runtime state - private to this file, nothing outside hue.cpp
+// needs any of it (previously these were WLED_GLOBAL, a leftover from when all
+// state lived in one big extern block regardless of who actually used it).
+static float hueXLast = 0, hueYLast = 0;
+static uint16_t hueHueLast = 0, hueCtLast = 0;
+static byte hueSatLast = 0, hueBriLast = 0;
+static unsigned long hueLastRequestSent = 0;
+static bool hueAuthRequired = false;
+static bool hueReceived = false;
+static bool hueNewKey = false;
+static AsyncClient *hueClient = nullptr;
+
 void handleHue()
 {
   if (hueReceived)

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -693,13 +693,9 @@ WLED_GLOBAL bool showWelcomePage _INIT(false);
 #ifndef WLED_DISABLE_HUESYNC
 WLED_GLOBAL byte hueError _INIT(HUE_ERROR_INACTIVE);
 // WLED_GLOBAL uint16_t hueFailCount _INIT(0);
-WLED_GLOBAL float hueXLast _INIT(0), hueYLast _INIT(0);
-WLED_GLOBAL uint16_t hueHueLast _INIT(0), hueCtLast _INIT(0);
-WLED_GLOBAL byte hueSatLast _INIT(0), hueBriLast _INIT(0);
-WLED_GLOBAL unsigned long hueLastRequestSent _INIT(0);
-WLED_GLOBAL bool hueAuthRequired _INIT(false);
-WLED_GLOBAL bool hueReceived _INIT(false);
-WLED_GLOBAL bool hueStoreAllowed _INIT(false), hueNewKey _INIT(false);
+// hueXLast/hueYLast/hueHueLast/hueCtLast/hueSatLast/hueBriLast/hueLastRequestSent/
+// hueAuthRequired/hueReceived/hueNewKey/hueClient are private to hue.cpp - see there.
+WLED_GLOBAL bool hueStoreAllowed _INIT(false);
 #endif
 
 // countdown
@@ -793,9 +789,6 @@ WLED_GLOBAL bool ledStatusState _INIT(false); // the current LED state
 WLED_GLOBAL AsyncWebServer server _INIT_N(((80, {0, WLED_REQUEST_MAX_QUEUE, WLED_REQUEST_MIN_HEAP, WLED_REQUEST_HEAP_USAGE})));
 #ifdef WLED_ENABLE_WEBSOCKETS
 WLED_GLOBAL AsyncWebSocket ws _INIT_N((("/ws")));
-#endif
-#ifndef WLED_DISABLE_HUESYNC
-WLED_GLOBAL AsyncClient     *hueClient _INIT(NULL);
 #endif
 WLED_GLOBAL AsyncWebHandler *editHandler _INIT(nullptr);
 


### PR DESCRIPTION
## Summary

11 `WLED_GLOBAL` variables declared in `wled.h` turned out to be referenced only in `hue.cpp` — nowhere else in `wled00/` or `usermods/` touches them: `hueXLast`, `hueYLast`, `hueHueLast`, `hueCtLast`, `hueSatLast`, `hueBriLast`, `hueLastRequestSent`, `hueAuthRequired`, `hueReceived`, `hueNewKey`, `hueClient`. They were global purely because everything in `wled.h` lives in one big `extern` block regardless of who actually uses it.

Converted all 11 to file-local `static` in `hue.cpp`, with the same types and initial values as before. `hueStoreAllowed`, which was declared on the same source line as `hueNewKey`, stays global since `set.cpp` also writes it — verified by grep before splitting that declaration.

No behavior change — purely a storage-class change, nothing else touched.

This is a small, mechanical first step from a broader pass identifying which of WLED's ~270 `WLED_GLOBAL` declarations are actually only used in one file (this is the largest single-file cluster).

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev` — 1,320,323 bytes flash, no warnings from either changed file.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that none of the 11 converted variables are referenced outside `hue.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of Hue synchronization state.
  * Reduced exposure of Hue-related implementation details while preserving existing behavior.
  * Hue synchronization continues to operate without changes to its user-facing functionality or configuration.
  * Internal state management is now more clearly separated from publicly accessible application interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
