### PR TITLE
Encapsulate network.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -436,6 +436,10 @@ void installIPv6RABlocker() {
 }
 #endif
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static byte apClients = 0;
+
 //handle Ethernet connection event
 void WiFiEvent(WiFiEvent_t event)
 {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -578,7 +578,7 @@ WLED_GLOBAL uint16_t userVar0 _INIT(0), userVar1 _INIT(0); //available for use i
 // internal global variable declarations
 // wifi
 WLED_GLOBAL bool apActive _INIT(false);
-WLED_GLOBAL byte apClients _INIT(0);
+// apClients is private to network.cpp - see there.
 WLED_GLOBAL bool forceReconnect _INIT(false);
 WLED_GLOBAL unsigned long lastReconnectAttempt _INIT(0);
 WLED_GLOBAL bool interfacesInited _INIT(false);


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5785 for earlier ones). `apClients` turned out to be private to `network.cpp`.

Converted it to file-local `static`, same type and initial value as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that `apClients` is not referenced outside `network.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)