### PR TITLE
Fixed nullptr crash in ETH IP comparing code

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -295,7 +295,7 @@ bool initEthernet()
   }
 
   // https://github.com/wled/WLED/issues/5247
-  if (multiWiFi[0].staticIP != (uint32_t)0x00000000 && multiWiFi[0].staticGW != (uint32_t)0x00000000) {
+  if (multiWiFi.size() && multiWiFi[0].staticIP != IPAddress() && multiWiFi[0].staticGW != IPAddress()) {
     ETH.config(multiWiFi[0].staticIP, multiWiFi[0].staticGW, multiWiFi[0].staticSN, dnsAddress);
   } else {
     ETH.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);


### PR DESCRIPTION
This PR fixes a nullptr crash when using ethernet.
The current implementation treats the passed value as a pointer, and since it is 0, it causes a crash.
<img width="764" height="234" alt="image" src="https://github.com/user-attachments/assets/f8756af6-aacb-47cd-a0d1-c1a95ffc2da3" />
Сomparing with `IPAddress()` is a more reliable option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethernet static IP configuration validation.
  * Static IP and gateway settings are now applied only when valid network configuration data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->