### PR TITLE
accept colon/dash separated BSSID in fillStr2MAC

### DIFF
--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -133,7 +133,7 @@ Identity:<br><input type="text" id="EI${i}" name="EI${i}" maxlength="64" value="
 Network name (SSID${i==0?", empty to not connect":""}):<br><input type="text" id="CS${i}" name="CS${i}" maxlength="32" value="${ssid}" ${i>0?"required":""}><br>
 ${encryptionTypeField}
 Network password:<br><input type="password" name="PW${i}" maxlength="64" value="${pass}"><br>
-BSSID (optional):<br><input type="text" id="BS${i}" name="BS${i}" maxlength="12" value="${bssid}"><br>
+BSSID (optional):<br><input type="text" id="BS${i}" name="BS${i}" maxlength="17" value="${bssid}" placeholder="9E2A6F44277A or 9E:2A:6F:44:27:7A"><br>
 Static IP (leave at 0.0.0.0 for DHCP)${i==0?"<br>Also used by Ethernet":""}:<br>
 <input name="IP${i}0" type="number" class="s" min="0" max="255" value="${ip&0xFF}" required>.<input name="IP${i}1" type="number" class="s" min="0" max="255" value="${(ip>>8)&0xFF}" required>.<input name="IP${i}2" type="number" class="s" min="0" max="255" value="${(ip>>16)&0xFF}" required>.<input name="IP${i}3" type="number" class="s" min="0" max="255" value="${(ip>>24)&0xFF}" required><br>
 Static gateway:<br>

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -339,8 +339,23 @@ void fillMAC2Str(char *str, const uint8_t *mac) {
 void fillStr2MAC(uint8_t *mac, const char *str) {
   for (int i = 0; i < 6; i++) *mac++ = 0;     // clear
   if (!str) return;                           // null string
-  uint64_t MAC = strtoull(str, nullptr, 16);
-  for (int i = 0; i < 6; i++) { *--mac = MAC & 0xFF; MAC >>= 8; }
+  // accept ":" / "-" / spaces; require exactly 12 hex digits
+  uint8_t nib[12];
+  int n = 0;
+  for (; *str; str++) {
+    char c = *str;
+    if (c == ':' || c == '-' || c == ' ') continue;
+    uint8_t v;
+    if      (c >= '0' && c <= '9') v = c - '0';
+    else if (c >= 'a' && c <= 'f') v = c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F') v = c - 'A' + 10;
+    else return;
+    if (n >= 12) return;
+    nib[n++] = v;
+  }
+  if (n != 12) return;
+  mac -= 6;
+  for (int i = 0; i < 6; i++) mac[i] = (nib[i*2] << 4) | nib[i*2+1];
 }
 
 


### PR DESCRIPTION
## Summary
- Parse BSSID with `:` / `-` separators in `fillStr2MAC` instead of stopping at the first non-hex char via `strtoull`.
- Raise the WiFi settings BSSID input `maxlength` so colon-separated MACs are not truncated.

## Test plan
- [ ] Enter `9E:2A:6F:44:27:7A` in WiFi Setup → BSSID, save, confirm `GET /json/cfg` shows the intended BSSID
- [ ] Confirm bare hex `9E2A6F44277A` still works
- [ ] Confirm BSSID pinning selects the intended AP

Fixes #5797


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the optional BSSID field to accept unformatted and colon-separated MAC address formats.
  * Added support for MAC addresses using colons, hyphens, or spaces as separators.
  * Added a placeholder showing supported MAC address formats.

* **Bug Fixes**
  * Improved validation to reject invalid, incomplete, or oversized MAC addresses.
  * BSSID entries are now checked for valid hexadecimal characters and the correct number of digits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->