### PR TITLE
Fix dynarray support for multiple arrays (16_x)

### DIFF
--- a/pio-scripts/dynarray.py
+++ b/pio-scripts/dynarray.py
@@ -10,7 +10,7 @@ from pathlib import Path
 DYNARRAY_INJECTION = (
     "\n    /* dynarray: WLED dynamic module arrays */\n"
     "    . = ALIGN(0x10);\n"
-    "    KEEP(*(SORT_BY_INIT_PRIORITY(.dynarray.*)))\n"
+    "    KEEP(*(SORT(.dynarray.*)))\n"
     "    "
 )
 

--- a/pio-scripts/validate_modules.py
+++ b/pio-scripts/validate_modules.py
@@ -103,7 +103,7 @@ def check_elf_modules(elf_path: Path, env, module_lib_builders) -> set[str]:
 def count_usermod_objects(map_file: list[str]) -> int:
     """ Returns the number of usermod objects in the usermod list.
 
-    Computes the count from the address span between the .dynarray.usermods.0
+    Computes the count from the address span between the .dynarray.usermods.00000
     and .dynarray.usermods.99999 sentinel sections.  This mirrors the
     DYNARRAY_LENGTH macro and is reliable under LTO, where all entries are
     merged into a single ltrans partition so counting section occurrences
@@ -115,7 +115,7 @@ def count_usermod_objects(map_file: list[str]) -> int:
 
     for i, line in enumerate(map_file):
         stripped = line.strip()
-        if stripped == '.dynarray.usermods.0':
+        if stripped == '.dynarray.usermods.00000':
             if i + 1 < len(map_file):
                 m = re.search(r'0x([0-9a-fA-F]+)', map_file[i + 1])
                 if m:

--- a/wled00/dynarray.h
+++ b/wled00/dynarray.h
@@ -9,15 +9,30 @@ Macros for generating a "dynamic array", a static array of objects declared in d
 // Declare the beginning and ending elements of a dynamic array of 'type'.
 // This must be used in only one translation unit in your program for any given array.
 #define DECLARE_DYNARRAY(type, array_name) \
-  static type const DYNARRAY_BEGIN(array_name)[0] __attribute__((__section__(DYNARRAY_SECTION "." #array_name ".0"), unused)) = {}; \
+  static type const DYNARRAY_BEGIN(array_name)[0] __attribute__((__section__(DYNARRAY_SECTION "." #array_name ".00000"), unused)) = {}; \
   static type const DYNARRAY_END(array_name)[0] __attribute__((__section__(DYNARRAY_SECTION "." #array_name ".99999"), unused)) = {};
 
-// Declare an object that is a member of a dynamic array.  "member name" must be unique; "array_section" is an integer for ordering items.
+// Declare an object that is a member of a dynamic array.  "member name" must be unique; "array_section" is 5-digit integer for ordering items.
 // It is legal to define multiple items with the same section name; the order of those items will be up to the linker.
-#define DYNARRAY_MEMBER(type, array_name, member_name, array_section) type const member_name __attribute__((__section__(DYNARRAY_SECTION "." #array_name "." #array_section), used))
+#define DYNARRAY_MEMBER(type, array_name, member_name, array_section) \
+  DYNARRAY_CHECK_SECTION(#array_section) \
+  type const member_name __attribute__((__section__(DYNARRAY_SECTION "." #array_name "." #array_section), used))
 
 #define DYNARRAY_BEGIN(array_name) array_name##_begin
 #define DYNARRAY_END(array_name) array_name##_end
 #define DYNARRAY_LENGTH(array_name) (&DYNARRAY_END(array_name)[0] - &DYNARRAY_BEGIN(array_name)[0])
+
+// The ordering key is pasted verbatim in to the section name, so it must be exactly five digits:
+// the linker sorts sections lexicographically, and zero padding is what makes that match numeric order.
+// The check is applied to the same stringified token the section attribute uses, so passing a macro that
+// expands to a number fails here, just as it would produce a bad section name.
+#define DYNARRAY_IS_DIGIT(s, i) ((s)[i] >= '0' && (s)[i] <= '9')
+#define DYNARRAY_IS_KEY(s) (sizeof(s) == 6 && DYNARRAY_IS_DIGIT(s, 0) && DYNARRAY_IS_DIGIT(s, 1) && DYNARRAY_IS_DIGIT(s, 2) && DYNARRAY_IS_DIGIT(s, 3) && DYNARRAY_IS_DIGIT(s, 4))
+#ifdef __cplusplus
+#define DYNARRAY_CHECK_SECTION(str) \
+  static_assert(DYNARRAY_IS_KEY(str), "DYNARRAY_MEMBER ordering key '" str "' must be exactly 5 digits, eg. 00100");
+#else
+#define DYNARRAY_CHECK_SECTION(str)  // no constant string subscripting in C
+#endif
 
 #define DYNARRAY_SECTION ".dynarray"

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -412,7 +412,7 @@ namespace UsermodManager {
 };
 
 // Register usermods by building a static list via a linker section
-#define REGISTER_USERMOD(x) DYNARRAY_MEMBER(Usermod*, usermods, um_##x, 1) = &x
+#define REGISTER_USERMOD(x) DYNARRAY_MEMBER(Usermod*, usermods, um_##x, 00001) = &x
 
 //usermod.cpp
 void userSetup();


### PR DESCRIPTION
Backport of #5814, as requested by @lost-hope .

---

The dynarray linker script was incorrectly merging multiple arrays. Use a strict alphanumeric sort to ensure entries are correctly ordered.

Note this adds a hard requirement that the numeric section keys must always be exactly 5 digits (ie. zero-padded). Since this cannot be done with a macro, a validation is added instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of dynamic module registration and initialization across supported platforms.
  - Corrected module ordering so registered components are processed consistently.
  - Added validation to catch incorrectly formatted registration identifiers during C++ builds.
  - Updated platform integration to preserve all dynamic-array entries and prevent valid modules from being omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->