### PR TITLE
Don't compile the installIPv6RABlocker if unused

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -320,7 +320,12 @@ void fillMAC2Str(char *str, const uint8_t *mac);
 void fillStr2MAC(uint8_t *mac, const char *str);
 int  findWiFi(bool doScan = false);
 bool isWiFiConfigured();
+#if defined(ARDUINO_ARCH_ESP32) && defined(LWIP_IPV6)
+#if ESP_IDF_VERSION_MAJOR < 5
+// Don't compile the function if it's not used
 void installIPv6RABlocker();
+#endif
+#endif
 void WiFiEvent(WiFiEvent_t event);
 
 //um_manager.cpp

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -430,10 +430,13 @@ static u8_t blockRouterAdvertisements(void* arg, struct raw_pcb* pcb, struct pbu
   return 0; // not consumed, pass it on
 }
 
+#if ESP_IDF_VERSION_MAJOR < 5
+// Don't compile the function if it's not used
 void installIPv6RABlocker() {
   struct raw_pcb* ra_blocker = raw_new_ip_type(IPADDR_TYPE_V6, IP6_NEXTH_ICMP6);
   raw_recv(ra_blocker, blockRouterAdvertisements, NULL);
 }
+#endif
 #endif
 
 //handle Ethernet connection event


### PR DESCRIPTION
The function `installIPv6RABlocker()` installs a raw-ICMPv6 callback that blackholes unsolicited IPv6 router advertisements, working around the LwIP bug where an RA overwrites the IPv4 DNS servers. That workaround is only needed on ESP-IDF v4 and older: the call site in `wled.cpp` has been gated on `ESP_IDF_VERSION_MAJOR < 5` for a while, but the function's *definition* (`network.cpp`) and *declaration* (`fcn_declare.h`) were not.

So on ESP-IDF v5 targets the function was still compiled and emitted into the binary despite having no callers. This adds the matching guards so the three sites agree.

No behavioural change on any target: on IDF v4 the blocker is compiled and installed exactly as before; on IDF v5 it was never called, and now simply isn't built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 networking compatibility on ESP32 devices using ESP-IDF 5 and newer.
  * Removed an obsolete IPv6 workaround where it is no longer required.
  * Preserved the workaround for supported older ESP-IDF versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->