### PR TITLE
warn when effect registration exceeds the list limit

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -10965,6 +10965,8 @@ uint8_t WS2812FX::addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name)
     if (_modeCount < _mode.size()) _modeCount++;
     return _mode.size() - 1;
   } else {
+    DEBUG_PRINT(F("WARNING: effect list full, could not add effect: "));
+    DEBUG_PRINTLN(FPSTR(mode_name));
     return 255; // The vector is full so return 255
   }
 }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -929,7 +929,7 @@ class WS2812FX {
     uint8_t getFirstSelectedSegId() const;
     uint8_t getLastActiveSegmentId() const;
     uint8_t getActiveSegsLightCapabilities(bool selectedOnly = false) const;
-    uint8_t addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name);         // mode_name must point to PROGMEM data; defined in FX.cpp;
+    uint8_t addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name);         // add effect to the list - mode_name must point to PROGMEM; defined in FX.cpp;
 
     inline uint8_t getBrightness() const    { return _brightness; }       // returns current strip brightness
     inline static constexpr unsigned getMaxSegments() { return MAX_NUM_SEGMENTS; }  // returns maximum number of supported segments (fixed value)

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -929,7 +929,7 @@ class WS2812FX {
     uint8_t getFirstSelectedSegId() const;
     uint8_t getLastActiveSegmentId() const;
     uint8_t getActiveSegsLightCapabilities(bool selectedOnly = false) const;
-    uint8_t addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name);         // add effect to the list; defined in FX.cpp;
+    uint8_t addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name);         // mode_name must point to PROGMEM data; defined in FX.cpp;
 
     inline uint8_t getBrightness() const    { return _brightness; }       // returns current strip brightness
     inline static constexpr unsigned getMaxSegments() { return MAX_NUM_SEGMENTS; }  // returns maximum number of supported segments (fixed value)


### PR DESCRIPTION
AI-generated contribution. I am the human operator responsible for follow-up with maintainers. Please feel free to close this PR or request any changes.

Fixes #5827.

When `WS2812FX::addEffect()` reaches the 254-effect capacity, it currently returns `255` silently. Most usermods discard that return value, so dropped effects are difficult to diagnose.

This adds a debug warning only on the full-list failure path and includes the effect metadata string that could not be registered. It intentionally does not change the 8-bit effect ID limit or overlap with the separate larger-effect-ID work.

Validation:
- `git diff --check`
- reviewed against current `main`

I could not run a firmware build locally because PlatformIO is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Diagnostics**
  - Added diagnostic messages when the effect list reaches its maximum capacity, including a warning and the affected effect name. This makes failed effect registration easier to identify during troubleshooting.

- **Documentation**
  - Clarified that effect names supplied when registering effects must be stored in program memory, helping developers provide effect metadata in the required format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->