### PR TITLE
Add HUB75 pinout for Seengreat RGB Matrix HUB75 S3 board (SKU 260612)

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -937,7 +937,7 @@ BusHub75Matrix::BusHub75Matrix(const BusConfig &bc) : Bus(bc.type, bc.start, bc.
                     7, 48, 6, 47, 2,   //  A_PIN,  B_PIN,  C_PIN,  D_PIN,  E_PIN,
                     21, 4, 5 };        // LAT_PIN, OE_PIN,CLK_PIN
 
-  #elif defined(SEENGREAT_HUB75_MATRIX_S3_PINOUT)
+  #elif defined(SEENGREAT_MATRIX_S3_PINOUT)
   DEBUGBUS_PRINTLN("MatrixPanel_I2S_DMA - Seengreat RGB Matrix HUB75 S3 pinout");
   // https://seengreat.com/wiki/214 (dedicated HUB75 board, SKU 260612 - NOT the same board/pinout as SEENGREAT_V1/V2_S3_PINOUT above)
   mxconfig.gpio = {  5,  4,  6,        // R1_PIN, G1_PIN, B1_PIN,

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -937,6 +937,14 @@ BusHub75Matrix::BusHub75Matrix(const BusConfig &bc) : Bus(bc.type, bc.start, bc.
                     7, 48, 6, 47, 2,   //  A_PIN,  B_PIN,  C_PIN,  D_PIN,  E_PIN,
                     21, 4, 5 };        // LAT_PIN, OE_PIN,CLK_PIN
 
+  #elif defined(SEENGREAT_HUB75_MATRIX_S3_PINOUT)
+  DEBUGBUS_PRINTLN("MatrixPanel_I2S_DMA - Seengreat RGB Matrix HUB75 S3 pinout");
+  // https://seengreat.com/wiki/214 (dedicated HUB75 board, SKU 260612 - NOT the same board/pinout as SEENGREAT_V1/V2_S3_PINOUT above)
+  mxconfig.gpio = {  5,  4,  6,        // R1_PIN, G1_PIN, B1_PIN,
+                    15,  7, 17,        // R2_PIN, G2_PIN, B2_PIN,
+                     8, 18, 10,  9, 16,//  A_PIN,  B_PIN,  C_PIN,  D_PIN,  E_PIN,
+                    11, 13, 12 };      // LAT_PIN, OE_PIN,CLK_PIN
+
   #else
   DEBUGBUS_PRINTLN("MatrixPanel_I2S_DMA - S3 generic pinout");
   // HUB75_I2S_CFG::i2s_pins _pins={R1_PIN, G1_PIN, B1_PIN, R2_PIN, G2_PIN, B2_PIN, A_PIN, B_PIN, C_PIN, D_PIN, E_PIN, LAT_PIN, OE_PIN, CLK_PIN};


### PR DESCRIPTION
## Summary
- Adds a new `SEENGREAT_HUB75_MATRIX_S3_PINOUT` HUB75 pin mapping for the Seengreat RGB Matrix HUB75 S3 (SKU 260612) [Wiki](https://seengreat.com/wiki/214)
- This is a dedicated HUB75 driver board, distinct from the existing `SEENGREAT_V1_S3_PINOUT` / `SEENGREAT_V2_S3_PINOUT` options, which target a different devkit+adapter combo and use different GPIO mappings

#### How it was tested
- [x] Built and flashed to the Seengreat RGB Matrix HUB75 S3 board with `-D SEENGREAT_HUB75_MATRIX_S3_PINOUT` and confirmed the panel drives correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Other**
  - No user-facing changes. The ESP32-S3 Seengreat HUB75 configuration naming was updated internally; board support and GPIO mappings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->